### PR TITLE
Add duplicatehost

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -707,3 +707,41 @@ class FessAPIClient:
         url = f"{self.base_url}/api/admin/boostdoc/settings"
         params = {"page": page, "size": size}
         return self.send_request(Action.LIST, url, params=params)
+
+    # DuplicateHost APIs
+
+    def create_duplicatehost(self, config: dict) -> dict:
+        """
+        Creates a new DuplicateHost.
+        """
+        url = f"{self.base_url}/api/admin/duplicatehost/setting"
+        return self.send_request(Action.CREATE, url, json=config)
+
+    def update_duplicatehost(self, config: dict) -> dict:
+        """
+        Updates an existing DuplicateHost.
+        """
+        url = f"{self.base_url}/api/admin/duplicatehost/setting"
+        return self.send_request(Action.EDIT, url, json=config)
+
+    def delete_duplicatehost(self, config_id: str) -> dict:
+        """
+        Deletes a DuplicateHost by ID.
+        """
+        url = f"{self.base_url}/api/admin/duplicatehost/setting/{config_id}"
+        return self.send_request(Action.DELETE, url)
+
+    def get_duplicatehost(self, config_id: str) -> dict:
+        """
+        Retrieves a DuplicateHost by ID.
+        """
+        url = f"{self.base_url}/api/admin/duplicatehost/setting/{config_id}"
+        return self.send_request(Action.GET, url)
+
+    def list_duplicatehosts(self, page: int = 1, size: int = 100) -> dict:
+        """
+        Retrieves a list of DuplicateHosts.
+        """
+        url = f"{self.base_url}/api/admin/duplicatehost/settings"
+        params = {"page": page, "size": size}
+        return self.send_request(Action.LIST, url, params=params)

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -10,6 +10,7 @@ from fessctl.commands.badword import badword_app
 from fessctl.commands.boostdoc import boostdoc_app
 from fessctl.commands.crawlinginfo import crawlinginfo_app
 from fessctl.commands.dataconfig import dataconfig_app
+from fessctl.commands.duplicatehost import duplicatehost_app
 from fessctl.commands.fileauth import fileauth_app
 from fessctl.commands.fileconfig import fileconfig_app
 from fessctl.commands.group import group_app
@@ -28,6 +29,7 @@ app.add_typer(badword_app, name="badword")
 app.add_typer(boostdoc_app, name="boostdoc")
 app.add_typer(crawlinginfo_app, name="crawlinginfo")
 app.add_typer(dataconfig_app, name="dataconfig")
+app.add_typer(duplicatehost_app, name="duplicatehost")
 app.add_typer(fileauth_app, name="fileauth")
 app.add_typer(fileconfig_app, name="fileconfig")
 app.add_typer(group_app, name="group")

--- a/src/fessctl/commands/duplicatehost.py
+++ b/src/fessctl/commands/duplicatehost.py
@@ -1,0 +1,280 @@
+import datetime
+import json
+from typing import List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from fessctl.api.client import FessAPIClient
+from fessctl.utils import to_utc_iso8601
+
+duplicatehost_app = typer.Typer()
+
+
+@duplicatehost_app.command("create")
+def create_duplicatehost(
+    regular_name: str = typer.Option(..., "--regular-name", help="Regular host name"),
+    duplicate_host_name: str = typer.Option(
+        ..., "--duplicate-host-name", help="Duplicate host name"
+    ),
+    sort_order: int = typer.Option(
+        ..., "--sort-order", help="Sort order (non-negative integer)"
+    ),
+    created_by: str = typer.Option("admin", "--created-by", help="Created by"),
+    created_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--created-time",
+        help="Created time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"
+    ),
+):
+    """
+    Create a new DuplicateHost.
+    """
+    client = FessAPIClient()
+
+    config = {
+        "crud_mode": 1,
+        "regular_name": regular_name,
+        "duplicate_host_name": duplicate_host_name,
+        "sort_order": sort_order,
+        "created_by": created_by,
+        "created_time": created_time,
+    }
+
+    result = client.create_duplicatehost(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            dup_id = result.get("response", {}).get("id", "")
+            typer.secho(
+                f"DuplicateHost '{dup_id}' created successfully.", fg=typer.colors.GREEN
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to create DuplicateHost. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@duplicatehost_app.command("update")
+def update_duplicatehost(
+    config_id: str = typer.Argument(..., help="DuplicateHost ID"),
+    regular_name: Optional[str] = typer.Option(
+        None, "--regular-name", help="Regular host name"
+    ),
+    duplicate_host_name: Optional[str] = typer.Option(
+        None, "--duplicate-host-name", help="Duplicate host name"
+    ),
+    sort_order: Optional[int] = typer.Option(
+        None, "--sort-order", help="Sort order (non-negative integer)"
+    ),
+    updated_by: str = typer.Option("admin", "--updated-by", help="Updated by"),
+    updated_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--updated-time",
+        help="Updated time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"
+    ),
+):
+    """
+    Update an existing DuplicateHost.
+    """
+    client = FessAPIClient()
+    result = client.get_duplicatehost(config_id)
+    if result.get("response", {}).get("status", 1) != 0:
+        message: str = result.get("response", {}).get("message", "")
+        typer.secho(
+            f"DuplicateHost with ID '{config_id}' not found. {message}",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=1)
+
+    config = result.get("response", {}).get("setting", {})
+    config["crud_mode"] = 2
+    config["updated_by"] = updated_by
+    config["updated_time"] = updated_time
+
+    if regular_name is not None:
+        config["regular_name"] = regular_name
+    if duplicate_host_name is not None:
+        config["duplicate_host_name"] = duplicate_host_name
+    if sort_order is not None:
+        config["sort_order"] = sort_order
+
+    result = client.update_duplicatehost(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"DuplicateHost '{config_id}' updated successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to update DuplicateHost. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@duplicatehost_app.command("delete")
+def delete_duplicatehost(
+    config_id: str = typer.Argument(..., help="DuplicateHost ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"
+    ),
+):
+    """
+    Delete a DuplicateHost by ID.
+    """
+    client = FessAPIClient()
+    result = client.delete_duplicatehost(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"DuplicateHost '{config_id}' deleted successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to delete DuplicateHost. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@duplicatehost_app.command("get")
+def get_duplicatehost(
+    config_id: str = typer.Argument(..., help="DuplicateHost ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"
+    ),
+):
+    """
+    Retrieve a DuplicateHost by ID.
+    """
+    client = FessAPIClient()
+    result = client.get_duplicatehost(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            duplicatehost = result.get("response", {}).get("setting", {})
+            console = Console()
+            table = Table(
+                title=f"DuplicateHost Details: {duplicatehost.get('id', '-')}"
+            )
+            table.add_column("Field", style="cyan", no_wrap=True)
+            table.add_column("Value", style="magenta")
+
+            # 正しい public name ベースのフィールドのみを表示
+            table.add_row("id", str(duplicatehost.get("id", "-")))
+            table.add_row("regular_name", str(duplicatehost.get("regular_name", "-")))
+            table.add_row(
+                "duplicate_host_name",
+                str(duplicatehost.get("duplicate_host_name", "-")),
+            )
+            table.add_row("sort_order", str(duplicatehost.get("sort_order", "-")))
+            table.add_row("version_no", str(duplicatehost.get("version_no", "-")))
+            table.add_row("crud_mode", str(duplicatehost.get("crud_mode", "-")))
+            table.add_row("updated_by", str(duplicatehost.get("updated_by", "-")))
+            table.add_row(
+                "updated_time", to_utc_iso8601(duplicatehost.get("updated_time"))
+            )
+            table.add_row("created_by", str(duplicatehost.get("created_by", "-")))
+            table.add_row(
+                "created_time", to_utc_iso8601(duplicatehost.get("created_time"))
+            )
+
+            console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to retrieve DuplicateHost. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@duplicatehost_app.command("list")
+def list_duplicatehosts(
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    size: int = typer.Option(100, "--size", "-s", help="Page size"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"
+    ),
+):
+    """
+    List DuplicateHosts.
+    """
+    client = FessAPIClient()
+    result = client.list_duplicatehosts(page=page, size=size)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            duplicatehosts = result.get("response", {}).get("settings", [])
+            if not duplicatehosts:
+                typer.secho("No DuplicateHosts found.", fg=typer.colors.YELLOW)
+            else:
+                console = Console()
+                table = Table(title="DuplicateHosts")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("REGULAR NAME", style="magenta")
+                table.add_column("DUPLICATE HOST NAME", style="green")
+                table.add_column("SORT ORDER", style="yellow")
+                table.add_column("UPDATED BY", style="blue")
+                table.add_column("UPDATED TIME", style="white")
+
+                for dh in duplicatehosts:
+                    table.add_row(
+                        dh.get("id", "-"),
+                        dh.get("regular_name", "-"),
+                        dh.get("duplicate_host_name", "-"),
+                        str(dh.get("sort_order", "-")),
+                        dh.get("updated_by", "-"),
+                        to_utc_iso8601(dh.get("updated_time")),
+                    )
+                console.print(table)
+        else:
+            message = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to list DuplicateHosts. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)


### PR DESCRIPTION
This pull request introduces a new feature to manage `DuplicateHost` configurations in the `fessctl` CLI tool. The changes include adding a new set of API methods, integrating the feature into the CLI, and implementing commands for CRUD operations and listing `DuplicateHost` entries.

### API Enhancements:
* Added methods for `create_duplicatehost`, `update_duplicatehost`, `delete_duplicatehost`, `get_duplicatehost`, and `list_duplicatehosts` in `FessAPIClient`. These methods handle API requests for managing `DuplicateHost` configurations.

### CLI Integration:
* Registered a new Typer application, `duplicatehost_app`, in `src/fessctl/cli.py` to enable `DuplicateHost` commands in the CLI. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R13) [[2]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R32)

### `DuplicateHost` Commands:
* Implemented CLI commands in `src/fessctl/commands/duplicatehost.py` for:
  - Creating a new `DuplicateHost` (`create` command).
  - Updating an existing `DuplicateHost` (`update` command).
  - Deleting a `DuplicateHost` by ID (`delete` command).
  - Retrieving a `DuplicateHost` by ID (`get` command).
  - Listing all `DuplicateHost` entries with pagination (`list` command).