### PR TITLE
Add keymatch

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -783,3 +783,41 @@ class FessAPIClient:
         url = f"{self.base_url}/api/admin/elevateword/settings"
         params = {"page": page, "size": size}
         return self.send_request(Action.LIST, url, params=params)
+
+    # KeyMatch APIs
+
+    def create_keymatch(self, config: dict) -> dict:
+        """
+        Creates a new KeyMatch.
+        """
+        url = f"{self.base_url}/api/admin/keymatch/setting"
+        return self.send_request(Action.CREATE, url, json=config)
+
+    def update_keymatch(self, config: dict) -> dict:
+        """
+        Updates an existing KeyMatch.
+        """
+        url = f"{self.base_url}/api/admin/keymatch/setting"
+        return self.send_request(Action.EDIT, url, json=config)
+
+    def delete_keymatch(self, config_id: str) -> dict:
+        """
+        Deletes a KeyMatch by ID.
+        """
+        url = f"{self.base_url}/api/admin/keymatch/setting/{config_id}"
+        return self.send_request(Action.DELETE, url)
+
+    def get_keymatch(self, config_id: str) -> dict:
+        """
+        Retrieves a KeyMatch by ID.
+        """
+        url = f"{self.base_url}/api/admin/keymatch/setting/{config_id}"
+        return self.send_request(Action.GET, url)
+
+    def list_keymatchs(self, page: int = 1, size: int = 100) -> dict:
+        """
+        Retrieves a list of KeyMatchs.
+        """
+        url = f"{self.base_url}/api/admin/keymatch/settings"
+        params = {"page": page, "size": size}
+        return self.send_request(Action.LIST, url, params=params)

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -16,6 +16,7 @@ from fessctl.commands.fileauth import fileauth_app
 from fessctl.commands.fileconfig import fileconfig_app
 from fessctl.commands.group import group_app
 from fessctl.commands.joblog import joblog_app
+from fessctl.commands.keymatch import keymatch_app
 from fessctl.commands.role import role_app
 from fessctl.commands.scheduler import scheduler_app
 from fessctl.commands.user import user_app
@@ -36,6 +37,7 @@ app.add_typer(fileauth_app, name="fileauth")
 app.add_typer(fileconfig_app, name="fileconfig")
 app.add_typer(group_app, name="group")
 app.add_typer(joblog_app, name="joblog")
+app.add_typer(keymatch_app, name="keymatch")
 app.add_typer(role_app, name="role")
 app.add_typer(scheduler_app, name="scheduler")
 app.add_typer(user_app, name="user")

--- a/src/fessctl/commands/keymatch.py
+++ b/src/fessctl/commands/keymatch.py
@@ -1,0 +1,275 @@
+import datetime
+import json
+from typing import List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from fessctl.api.client import FessAPIClient
+from fessctl.utils import to_utc_iso8601
+
+keymatch_app = typer.Typer()
+
+
+@keymatch_app.command("create")
+def create_keymatch(
+    term: str = typer.Option(..., "--term", help="Search term to match"),
+    query: str = typer.Option(..., "--query",
+                              help="Query to execute when term matches"),
+    max_size: int = typer.Option(..., "--max-size",
+                                 help="Maximum result size"),
+    boost: float = typer.Option(..., "--boost", help="Boost value"),
+    version_no: int = typer.Option(..., "--version-no", help="Version number"),
+    virtual_host: Optional[str] = typer.Option(
+        None, "--virtual-host", help="Virtual host condition"),
+    created_by: str = typer.Option("admin", "--created-by", help="Created by"),
+    created_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--created-time",
+        help="Created time in milliseconds (UTC)"
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Create a new KeyMatch.
+    """
+    client = FessAPIClient()
+
+    config = {
+        "crud_mode": 1,
+        "term": term,
+        "query": query,
+        "max_size": max_size,
+        "boost": boost,
+        "version_no": version_no,
+        "created_by": created_by,
+        "created_time": created_time,
+    }
+    if virtual_host:
+        config["virtual_host"] = virtual_host
+
+    result = client.create_keymatch(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            keymatch_id = result.get("response", {}).get("id", "-")
+            typer.secho(
+                f"KeyMatch '{keymatch_id}' created successfully.", fg=typer.colors.GREEN)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to create KeyMatch. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@keymatch_app.command("update")
+def update_keymatch(
+    config_id: str = typer.Argument(..., help="KeyMatch ID"),
+    term: Optional[str] = typer.Option(
+        None, "--term", help="Search term to match"),
+    query: Optional[str] = typer.Option(
+        None, "--query", help="Query to execute when term matches"),
+    max_size: Optional[int] = typer.Option(
+        None, "--max-size", help="Maximum result size"),
+    boost: Optional[float] = typer.Option(None, "--boost", help="Boost value"),
+    version_no: Optional[int] = typer.Option(
+        None, "--version-no", help="Version number"),
+    virtual_host: Optional[str] = typer.Option(
+        None, "--virtual-host", help="Virtual host condition"),
+    updated_by: str = typer.Option("admin", "--updated-by", help="Updated by"),
+    updated_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--updated-time",
+        help="Updated time in milliseconds (UTC)"
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Update an existing KeyMatch.
+    """
+    client = FessAPIClient()
+    result = client.get_keymatch(config_id)
+    if result.get("response", {}).get("status", 1) != 0:
+        message: str = result.get("response", {}).get("message", "")
+        typer.secho(
+            f"KeyMatch with ID '{config_id}' not found. {message}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    config = result.get("response", {}).get("setting", {})
+    config["crud_mode"] = 2
+    config["updated_by"] = updated_by
+    config["updated_time"] = updated_time
+
+    if term is not None:
+        config["term"] = term
+    if query is not None:
+        config["query"] = query
+    if max_size is not None:
+        config["max_size"] = max_size
+    if boost is not None:
+        config["boost"] = boost
+    if version_no is not None:
+        config["version_no"] = version_no
+    if virtual_host is not None:
+        config["virtual_host"] = virtual_host
+
+    result = client.update_keymatch(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"KeyMatch '{config_id}' updated successfully.", fg=typer.colors.GREEN)
+        else:
+            message = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to update KeyMatch. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@keymatch_app.command("delete")
+def delete_keymatch(
+    config_id: str = typer.Argument(..., help="KeyMatch ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Delete a KeyMatch by ID.
+    """
+    client = FessAPIClient()
+    result = client.delete_keymatch(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"KeyMatch '{config_id}' deleted successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to delete KeyMatch. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@keymatch_app.command("get")
+def get_keymatch(
+    config_id: str = typer.Argument(..., help="KeyMatch ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Retrieve a KeyMatch by ID.
+    """
+    client = FessAPIClient()
+    result = client.get_keymatch(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            keymatch = result.get("response", {}).get("setting", {})
+            console = Console()
+            table = Table(title=f"KeyMatch Details: {keymatch.get('id', '-')}")
+            table.add_column("Field", style="cyan", no_wrap=True)
+            table.add_column("Value", style="magenta")
+
+            table.add_row("id", str(keymatch.get("id", "-")))
+            table.add_row("term", str(keymatch.get("term", "-")))
+            table.add_row("query", str(keymatch.get("query", "-")))
+            table.add_row("max_size", str(keymatch.get("max_size", "-")))
+            table.add_row("boost", str(keymatch.get("boost", "-")))
+            table.add_row("virtual_host", str(
+                keymatch.get("virtual_host", "-")))
+            table.add_row("version_no", str(keymatch.get("version_no", "-")))
+            table.add_row("crud_mode", str(keymatch.get("crud_mode", "-")))
+            table.add_row("created_by", str(keymatch.get("created_by", "-")))
+            table.add_row("created_time", to_utc_iso8601(
+                keymatch.get("created_time")))
+            table.add_row("updated_by", str(keymatch.get("updated_by", "-")))
+            table.add_row("updated_time", to_utc_iso8601(
+                keymatch.get("updated_time")))
+
+            console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to retrieve KeyMatch. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@keymatch_app.command("list")
+def list_keymatchs(
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    size: int = typer.Option(100, "--size", "-s", help="Page size"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    List KeyMatchs.
+    """
+    client = FessAPIClient()
+    result = client.list_keymatchs(page=page, size=size)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            keymatchs = result.get("response", {}).get("settings", [])
+            if not keymatchs:
+                typer.secho("No KeyMatchs found.", fg=typer.colors.YELLOW)
+            else:
+                console = Console()
+                table = Table(title="KeyMatchs")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("TERM", style="green")
+                table.add_column("QUERY", style="magenta")
+                table.add_column("BOOST", style="yellow")
+                table.add_column("MAX SIZE", style="blue")
+                table.add_column("UPDATED BY", style="white")
+                table.add_column("UPDATED TIME", style="white")
+
+                for km in keymatchs:
+                    table.add_row(
+                        km.get("id", "-"),
+                        km.get("term", "-"),
+                        km.get("query", "-"),
+                        str(km.get("boost", "-")),
+                        str(km.get("max_size", "-")),
+                        km.get("updated_by", "-"),
+                        to_utc_iso8601(km.get("updated_time")),
+                    )
+                console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to list KeyMatchs. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)


### PR DESCRIPTION
This pull request introduces a new feature for managing "KeyMatch" entities in the `fessctl` CLI and API client. KeyMatch-related commands have been added to the CLI, along with corresponding methods in the API client for creating, updating, deleting, retrieving, and listing KeyMatch configurations.

### KeyMatch API Integration:
* Added new API client methods in `src/fessctl/api/client.py` to handle KeyMatch operations: `create_keymatch`, `update_keymatch`, `delete_keymatch`, `get_keymatch`, and `list_keymatchs`. These methods interact with the `/api/admin/keymatch/setting` endpoints.

### KeyMatch CLI Commands:
* Introduced a new `keymatch` command group in `src/fessctl/commands/keymatch.py` with subcommands for managing KeyMatch entities:
  - `create`: Create a new KeyMatch.
  - `update`: Update an existing KeyMatch.
  - `delete`: Delete a KeyMatch by ID.
  - `get`: Retrieve a KeyMatch by ID.
  - [`list`](diffhunk://#diff-9bb9790c3b81380eb84ae2270d2fe43e4600af9af30d9b153c6b82734b5c20f8R1-R275): List all KeyMatchs with pagination support.

### CLI Integration:
* Registered the `keymatch` command group in the main CLI application (`src/fessctl/cli.py`). This allows users to access KeyMatch commands via the `fessctl keymatch` command. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R19) [[2]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R40)