### PR TITLE
Add labeltype

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -821,3 +821,41 @@ class FessAPIClient:
         url = f"{self.base_url}/api/admin/keymatch/settings"
         params = {"page": page, "size": size}
         return self.send_request(Action.LIST, url, params=params)
+
+    # LabelType APIs
+
+    def create_labeltype(self, config: dict) -> dict:
+        """
+        Creates a new LabelType.
+        """
+        url = f"{self.base_url}/api/admin/labeltype/setting"
+        return self.send_request(Action.CREATE, url, json=config)
+
+    def update_labeltype(self, config: dict) -> dict:
+        """
+        Updates an existing LabelType.
+        """
+        url = f"{self.base_url}/api/admin/labeltype/setting"
+        return self.send_request(Action.EDIT, url, json=config)
+
+    def delete_labeltype(self, config_id: str) -> dict:
+        """
+        Deletes a LabelType by ID.
+        """
+        url = f"{self.base_url}/api/admin/labeltype/setting/{config_id}"
+        return self.send_request(Action.DELETE, url)
+
+    def get_labeltype(self, config_id: str) -> dict:
+        """
+        Retrieves a LabelType by ID.
+        """
+        url = f"{self.base_url}/api/admin/labeltype/setting/{config_id}"
+        return self.send_request(Action.GET, url)
+
+    def list_labeltypes(self, page: int = 1, size: int = 100) -> dict:
+        """
+        Retrieves a list of LabelTypes.
+        """
+        url = f"{self.base_url}/api/admin/labeltype/settings"
+        params = {"page": page, "size": size}
+        return self.send_request(Action.LIST, url, params=params)

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -17,6 +17,7 @@ from fessctl.commands.fileconfig import fileconfig_app
 from fessctl.commands.group import group_app
 from fessctl.commands.joblog import joblog_app
 from fessctl.commands.keymatch import keymatch_app
+from fessctl.commands.labeltype import labeltype_app
 from fessctl.commands.role import role_app
 from fessctl.commands.scheduler import scheduler_app
 from fessctl.commands.user import user_app
@@ -38,6 +39,7 @@ app.add_typer(fileconfig_app, name="fileconfig")
 app.add_typer(group_app, name="group")
 app.add_typer(joblog_app, name="joblog")
 app.add_typer(keymatch_app, name="keymatch")
+app.add_typer(labeltype_app, name="labeltype")
 app.add_typer(role_app, name="role")
 app.add_typer(scheduler_app, name="scheduler")
 app.add_typer(user_app, name="user")

--- a/src/fessctl/commands/labeltype.py
+++ b/src/fessctl/commands/labeltype.py
@@ -1,0 +1,295 @@
+import datetime
+import json
+from typing import List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from fessctl.api.client import FessAPIClient
+from fessctl.utils import to_utc_iso8601
+
+labeltype_app = typer.Typer()
+
+
+@labeltype_app.command("create")
+def create_labeltype(
+    name: str = typer.Option(..., "--name", help="LabelType name"),
+    value: str = typer.Option(..., "--value", help="Label value"),
+    version_no: int = typer.Option(..., "--version-no", help="Version number"),
+    sort_order: int = typer.Option(0, "--sort-order", help="Sort order"),
+    included_paths: Optional[List[str]] = typer.Option(
+        [], "--included-path", help="Included paths"),
+    excluded_paths: Optional[List[str]] = typer.Option(
+        [], "--excluded-path", help="Excluded paths"),
+    permissions: Optional[List[str]] = typer.Option(
+        [], "--permission", help="Access permissions"),
+    virtual_host: Optional[str] = typer.Option(
+        None, "--virtual-host", help="Virtual host"),
+    created_by: str = typer.Option("admin", "--created-by", help="Created by"),
+    created_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--created-time",
+        help="Created time in milliseconds (UTC)"
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Create a new LabelType.
+    """
+    client = FessAPIClient()
+
+    config = {
+        "crud_mode": 1,
+        "name": name,
+        "value": value,
+        "version_no": version_no,
+        "sort_order": sort_order,
+        "created_by": created_by,
+        "created_time": created_time,
+    }
+
+    if included_paths:
+        config["included_paths"] = "\n".join(included_paths)
+    if excluded_paths:
+        config["excluded_paths"] = "\n".join(excluded_paths)
+    if permissions:
+        config["permissions"] = "\n".join(permissions)
+    if virtual_host:
+        config["virtual_host"] = virtual_host
+
+    result = client.create_labeltype(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            labeltype_id = result.get("response", {}).get("id", "")
+            typer.secho(
+                f"LabelType '{labeltype_id}' created successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to create LabelType. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@labeltype_app.command("update")
+def update_labeltype(
+    config_id: str = typer.Argument(..., help="LabelType ID"),
+    name: Optional[str] = typer.Option(None, "--name", help="LabelType name"),
+    value: Optional[str] = typer.Option(None, "--value", help="Label value"),
+    version_no: Optional[int] = typer.Option(
+        None, "--version-no", help="Version number"),
+    sort_order: Optional[int] = typer.Option(
+        None, "--sort-order", help="Sort order"),
+    included_paths: Optional[List[str]] = typer.Option(
+        None, "--included-path", help="Included paths"),
+    excluded_paths: Optional[List[str]] = typer.Option(
+        None, "--excluded-path", help="Excluded paths"),
+    permissions: Optional[List[str]] = typer.Option(
+        None, "--permission", help="Access permissions"),
+    virtual_host: Optional[str] = typer.Option(
+        None, "--virtual-host", help="Virtual host"),
+    updated_by: str = typer.Option("admin", "--updated-by", help="Updated by"),
+    updated_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--updated-time",
+        help="Updated time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Update an existing LabelType.
+    """
+    client = FessAPIClient()
+    result = client.get_labeltype(config_id)
+    if result.get("response", {}).get("status", 1) != 0:
+        message: str = result.get("response", {}).get("message", "")
+        typer.secho(
+            f"LabelType with ID '{config_id}' not found. {message}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    config = result.get("response", {}).get("setting", {})
+    config["crud_mode"] = 2
+    config["updated_by"] = updated_by
+    config["updated_time"] = updated_time
+
+    if name is not None:
+        config["name"] = name
+    if value is not None:
+        config["value"] = value
+    if version_no is not None:
+        config["version_no"] = version_no
+    if sort_order is not None:
+        config["sort_order"] = sort_order
+    if included_paths is not None:
+        config["included_paths"] = "\n".join(included_paths)
+    if excluded_paths is not None:
+        config["excluded_paths"] = "\n".join(excluded_paths)
+    if permissions is not None:
+        config["permissions"] = "\n".join(permissions)
+    if virtual_host is not None:
+        config["virtual_host"] = virtual_host
+
+    result = client.update_labeltype(config)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"LabelType '{config_id}' updated successfully.", fg=typer.colors.GREEN)
+        else:
+            message = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to update LabelType. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@labeltype_app.command("delete")
+def delete_labeltype(
+    config_id: str = typer.Argument(..., help="LabelType ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Delete a LabelType by ID.
+    """
+    client = FessAPIClient()
+    result = client.delete_labeltype(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"LabelType '{config_id}' deleted successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to delete LabelType. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@labeltype_app.command("get")
+def get_labeltype(
+    config_id: str = typer.Argument(..., help="LabelType ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Retrieve a LabelType by ID.
+    """
+    client = FessAPIClient()
+    result = client.get_labeltype(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            labeltype = result.get("response", {}).get("setting", {})
+            console = Console()
+            table = Table(
+                title=f"LabelType Details: {labeltype.get('id', '-')}")
+            table.add_column("Field", style="cyan", no_wrap=True)
+            table.add_column("Value", style="magenta")
+
+            table.add_row("id", str(labeltype.get("id", "-")))
+            table.add_row("name", str(labeltype.get("name", "-")))
+            table.add_row("value", str(labeltype.get("value", "-")))
+            table.add_row("version_no", str(labeltype.get("version_no", "-")))
+            table.add_row("sort_order", str(labeltype.get("sort_order", "-")))
+            table.add_row("included_paths", labeltype.get(
+                "included_paths", "").replace("\n", ", "))
+            table.add_row("excluded_paths", labeltype.get(
+                "excluded_paths", "").replace("\n", ", "))
+            table.add_row("permissions", labeltype.get(
+                "permissions", "").replace("\n", ", "))
+            table.add_row("virtual_host", str(
+                labeltype.get("virtual_host", "-")))
+            table.add_row("crud_mode", str(labeltype.get("crud_mode", "-")))
+            table.add_row("created_by", str(labeltype.get("created_by", "-")))
+            table.add_row("created_time", to_utc_iso8601(
+                labeltype.get("created_time")))
+            table.add_row("updated_by", str(labeltype.get("updated_by", "-")))
+            table.add_row("updated_time", to_utc_iso8601(
+                labeltype.get("updated_time")))
+
+            console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to retrieve LabelType. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@labeltype_app.command("list")
+def list_labeltypes(
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    size: int = typer.Option(100, "--size", "-s", help="Page size"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    List LabelTypes.
+    """
+    client = FessAPIClient()
+    result = client.list_labeltypes(page=page, size=size)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            labeltypes = result.get("response", {}).get("settings", [])
+            if not labeltypes:
+                typer.secho("No LabelTypes found.", fg=typer.colors.YELLOW)
+            else:
+                console = Console()
+                table = Table(title="LabelTypes")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("NAME", style="green")
+                table.add_column("VALUE", style="magenta")
+
+                for lt in labeltypes:
+                    table.add_row(
+                        lt.get("id", "-"),
+                        lt.get("name", "-"),
+                        lt.get("value", "-"),
+                    )
+                console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to list LabelTypes. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)


### PR DESCRIPTION
This pull request introduces support for managing LabelType entities in the `fessctl` CLI tool, including API client methods and CLI commands for CRUD operations. The most important changes are the addition of new API client methods, a new CLI module for LabelType commands, and integration of the LabelType commands into the main CLI application.

### API Client Enhancements:
* Added methods in `src/fessctl/api/client.py` to handle LabelType operations: `create_labeltype`, `update_labeltype`, `delete_labeltype`, `get_labeltype`, and `list_labeltypes`. These methods interact with the corresponding API endpoints for managing LabelTypes.

### CLI Integration:
* Integrated the `labeltype_app` module into the main CLI application by importing it and registering it as a subcommand in `src/fessctl/cli.py`. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R20) [[2]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R42)

### New CLI Module:
* Introduced a new module, `src/fessctl/commands/labeltype.py`, which provides CLI commands for managing LabelTypes. This includes commands for creating, updating, deleting, retrieving, and listing LabelTypes, with support for various input options and output formats (text, JSON, YAML).