### PR TITLE
Add pathmap

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -859,3 +859,41 @@ class FessAPIClient:
         url = f"{self.base_url}/api/admin/labeltype/settings"
         params = {"page": page, "size": size}
         return self.send_request(Action.LIST, url, params=params)
+
+    # PathMap APIs
+
+    def create_pathmap(self, config: dict) -> dict:
+        """
+        Creates a new PathMap.
+        """
+        url = f"{self.base_url}/api/admin/pathmap/setting"
+        return self.send_request(Action.CREATE, url, json=config)
+
+    def update_pathmap(self, config: dict) -> dict:
+        """
+        Updates an existing PathMap.
+        """
+        url = f"{self.base_url}/api/admin/pathmap/setting"
+        return self.send_request(Action.EDIT, url, json=config)
+
+    def delete_pathmap(self, config_id: str) -> dict:
+        """
+        Deletes a PathMap by ID.
+        """
+        url = f"{self.base_url}/api/admin/pathmap/setting/{config_id}"
+        return self.send_request(Action.DELETE, url)
+
+    def get_pathmap(self, config_id: str) -> dict:
+        """
+        Retrieves a PathMap by ID.
+        """
+        url = f"{self.base_url}/api/admin/pathmap/setting/{config_id}"
+        return self.send_request(Action.GET, url)
+
+    def list_pathmaps(self, page: int = 1, size: int = 100) -> dict:
+        """
+        Retrieves a list of PathMaps.
+        """
+        url = f"{self.base_url}/api/admin/pathmap/settings"
+        params = {"page": page, "size": size}
+        return self.send_request(Action.LIST, url, params=params)

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -10,16 +10,27 @@ from fessctl.commands.badword import badword_app
 from fessctl.commands.boostdoc import boostdoc_app
 from fessctl.commands.crawlinginfo import crawlinginfo_app
 from fessctl.commands.dataconfig import dataconfig_app
+# from fessctl.commands.documents import documents_app
 from fessctl.commands.duplicatehost import duplicatehost_app
 from fessctl.commands.elevateword import elevateword_app
+# from fessctl.commands.failureurl import failureurl_app
 from fessctl.commands.fileauth import fileauth_app
 from fessctl.commands.fileconfig import fileconfig_app
+# from fessctl.commands.general import general_app
 from fessctl.commands.group import group_app
 from fessctl.commands.joblog import joblog_app
 from fessctl.commands.keymatch import keymatch_app
 from fessctl.commands.labeltype import labeltype_app
+# from fessctl.commands.log import log_app
+from fessctl.commands.pathmap import pathmap_app
+# from fessctl.commands.plugin  import plugin_app
 from fessctl.commands.role import role_app
+# from fessctl.commands.searchlist import searchlist_app
 from fessctl.commands.scheduler import scheduler_app
+# from fessctl.commands.stats import stats_app
+# from fessctl.commands.storage import storage_app
+# from fessctl.commands.suggest import suggest_app
+# from fessctl.commands.systeminfo import systeminfo_app
 from fessctl.commands.user import user_app
 from fessctl.commands.webauth import webauth_app
 from fessctl.commands.webconfig import webconfig_app
@@ -32,16 +43,27 @@ app.add_typer(badword_app, name="badword")
 app.add_typer(boostdoc_app, name="boostdoc")
 app.add_typer(crawlinginfo_app, name="crawlinginfo")
 app.add_typer(dataconfig_app, name="dataconfig")
+# app.add_typer(documents_app, name="documents")
 app.add_typer(duplicatehost_app, name="duplicatehost")
 app.add_typer(elevateword_app, name="elevateword")
+# app.add_typer(failureurl_app, name="failureurl")
 app.add_typer(fileauth_app, name="fileauth")
 app.add_typer(fileconfig_app, name="fileconfig")
+# app.add_typer(general_app, name="general")
 app.add_typer(group_app, name="group")
 app.add_typer(joblog_app, name="joblog")
 app.add_typer(keymatch_app, name="keymatch")
 app.add_typer(labeltype_app, name="labeltype")
+# app.add_typer(log_app, name="log")
+app.add_typer(pathmap_app, name="pathmap")
+# app.add_typer(plugin_app, name="plugin")
 app.add_typer(role_app, name="role")
+# app.add_typer(searchlist_app, name="searchlist")
 app.add_typer(scheduler_app, name="scheduler")
+# app.add_typer(stats_app, name="stats")
+# app.add_typer(storage_app, name="storage")
+# app.add_typer(suggest_app, name="suggest")
+# app.add_typer(systeminfo_app, name="systeminfo")
 app.add_typer(user_app, name="user")
 app.add_typer(webauth_app, name="webauth")
 app.add_typer(webconfig_app, name="webconfig")

--- a/src/fessctl/commands/pathmap.py
+++ b/src/fessctl/commands/pathmap.py
@@ -1,0 +1,271 @@
+import datetime
+import json
+from typing import List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from fessctl.api.client import FessAPIClient
+from fessctl.utils import to_utc_iso8601
+
+pathmap_app = typer.Typer()
+
+
+@pathmap_app.command("create")
+def create_path(
+    regex: str = typer.Option(..., "--regex", help="Regex pattern to match"),
+    process_type: str = typer.Option(...,
+                                     "--process-type", help="Process type"),
+    replacement: Optional[str] = typer.Option(
+        None, "--replacement", help="Replacement string"),
+    sort_order: int = typer.Option(0, "--sort-order", help="Sort order"),
+    user_agent: Optional[str] = typer.Option(
+        None, "--user-agent", help="User agent"),
+    created_by: str = typer.Option("admin", "--created-by", help="Created by"),
+    created_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--created-time",
+        help="Created time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format"),
+):
+    """
+    Create a new Path Mapping.
+    """
+    client = FessAPIClient()
+
+    config = {
+        "crud_mode": 1,
+        "regex": regex,
+        "process_type": process_type,
+        "sort_order": sort_order,
+        "created_by": created_by,
+        "created_time": created_time,
+    }
+
+    if replacement is not None:
+        config["replacement"] = replacement
+    if user_agent is not None:
+        config["user_agent"] = user_agent
+
+    result = client.create_path(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            path_id = result.get("response", {}).get("id", "")
+            typer.secho(
+                f"Path Mapping '{path_id}' created successfully.", fg=typer.colors.GREEN)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to create Path Mapping. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@pathmap_app.command("update")
+def update_pathmap(
+    config_id: str = typer.Argument(..., help="PathMap ID"),
+    regex: Optional[str] = typer.Option(
+        None, "--regex", help="Regex pattern to match"),
+    process_type: Optional[str] = typer.Option(
+        None, "--process-type", help="Process type"),
+    replacement: Optional[str] = typer.Option(
+        None, "--replacement", help="Replacement string"),
+    sort_order: Optional[int] = typer.Option(
+        None, "--sort-order", help="Sort order"),
+    user_agent: Optional[str] = typer.Option(
+        None, "--user-agent", help="User agent"),
+    updated_by: str = typer.Option("admin", "--updated-by", help="Updated by"),
+    updated_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--updated-time",
+        help="Updated time in milliseconds (UTC)"
+    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format"),
+):
+    """
+    Update an existing PathMap.
+    """
+    client = FessAPIClient()
+    result = client.get_pathmap(config_id)
+    if result.get("response", {}).get("status", 1) != 0:
+        message: str = result.get("response", {}).get("message", "")
+        typer.secho(
+            f"PathMap with ID '{config_id}' not found. {message}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    config = result.get("response", {}).get("setting", {})
+    config["crud_mode"] = 2
+    config["updated_by"] = updated_by
+    config["updated_time"] = updated_time
+
+    if regex is not None:
+        config["regex"] = regex
+    if process_type is not None:
+        config["process_type"] = process_type
+    if replacement is not None:
+        config["replacement"] = replacement
+    if sort_order is not None:
+        config["sort_order"] = sort_order
+    if user_agent is not None:
+        config["user_agent"] = user_agent
+
+    result = client.update_pathmap(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"PathMap '{config_id}' updated successfully.", fg=typer.colors.GREEN)
+        else:
+            message = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to update PathMap. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@pathmap_app.command("delete")
+def delete_pathmap(
+    config_id: str = typer.Argument(..., help="PathMap ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Delete a PathMap by ID.
+    """
+    client = FessAPIClient()
+    result = client.delete_pathmap(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"PathMap '{config_id}' deleted successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to delete PathMap. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@pathmap_app.command("get")
+def get_pathmap(
+    config_id: str = typer.Argument(..., help="PathMap ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Retrieve a PathMap by ID.
+    """
+    client = FessAPIClient()
+    result = client.get_pathmap(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            pathmap = result.get("response", {}).get("setting", {})
+            console = Console()
+            table = Table(title=f"PathMap Details: {pathmap.get('id', '-')}")
+            table.add_column("Field", style="cyan", no_wrap=True)
+            table.add_column("Value", style="magenta")
+
+            # 正しい PathMap パラメータ出力
+            table.add_row("id", str(pathmap.get("id", "-")))
+            table.add_row("regex", str(pathmap.get("regex", "-")))
+            table.add_row("replacement", str(pathmap.get("replacement", "-")))
+            table.add_row("process_type", str(
+                pathmap.get("process_type", "-")))
+            table.add_row("sort_order", str(pathmap.get("sort_order", "-")))
+            table.add_row("user_agent", str(pathmap.get("user_agent", "-")))
+            table.add_row("version_no", str(pathmap.get("version_no", "-")))
+            table.add_row("crud_mode", str(pathmap.get("crud_mode", "-")))
+            table.add_row("updated_by", str(pathmap.get("updated_by", "-")))
+            table.add_row("updated_time", to_utc_iso8601(
+                pathmap.get("updated_time")))
+            table.add_row("created_by", str(pathmap.get("created_by", "-")))
+            table.add_row("created_time", to_utc_iso8601(
+                pathmap.get("created_time")))
+
+            console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to retrieve PathMap. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@pathmap_app.command("list")
+def list_pathmaps(
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    size: int = typer.Option(100, "--size", "-s", help="Page size"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    List PathMaps.
+    """
+    client = FessAPIClient()
+    result = client.list_pathmaps(page=page, size=size)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            pathmaps = result.get("response", {}).get("settings", [])
+            if not pathmaps:
+                typer.secho("No PathMaps found.", fg=typer.colors.YELLOW)
+            else:
+                console = Console()
+                table = Table(title="PathMaps")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("REGEX", style="magenta")
+                table.add_column("REPLACEMENT", style="green")
+                table.add_column("PROCESS TYPE", style="blue")
+                table.add_column("SORT ORDER", justify="right")
+                table.add_column("USER AGENT", style="yellow")
+
+                for pathmap in pathmaps:
+                    table.add_row(
+                        pathmap.get("id", "-"),
+                        pathmap.get("regex", "-"),
+                        pathmap.get("replacement", "-"),
+                        pathmap.get("process_type", "-"),
+                        str(pathmap.get("sort_order", "-")),
+                        pathmap.get("user_agent", "-"),
+                    )
+                console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to list PathMaps. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)


### PR DESCRIPTION
This pull request introduces a new feature for managing PathMap configurations in the `fessctl` CLI tool. It includes updates to the API client, CLI command registration, and the addition of a dedicated `pathmap` command module. The most important changes are outlined below.

### PathMap API Integration:

* Added methods to the `FessAPIClient` for creating, updating, deleting, retrieving, and listing PathMap configurations (`create_pathmap`, `update_pathmap`, `delete_pathmap`, `get_pathmap`, `list_pathmaps`) in `src/fessctl/api/client.py`. These methods interact with the corresponding endpoints of the Fess API.

### CLI Enhancements:

* Registered the `pathmap` command in `src/fessctl/cli.py`, enabling users to manage PathMap configurations via the CLI. Several other commands were commented out, likely for future cleanup or deprecation. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R13-R33) [[2]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R46-R66)

### New `pathmap` Command Module:

* Added a new `pathmap` module in `src/fessctl/commands/pathmap.py` with commands for:
  - Creating a PathMap (`create_path`).
  - Updating a PathMap (`update_pathmap`).
  - Deleting a PathMap (`delete_pathmap`).
  - Retrieving a PathMap by ID (`get_pathmap`).
  - Listing all PathMaps (`list_pathmaps`).
  These commands support various output formats (text, JSON, YAML) and provide detailed feedback on operation success or failure.