### PR TITLE
Add relatedquery

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -935,3 +935,41 @@ class FessAPIClient:
         url = f"{self.base_url}/api/admin/relatedcontent/settings"
         params = {"page": page, "size": size}
         return self.send_request(Action.LIST, url, params=params)
+
+    # RelatedQuery APIs
+
+    def create_relatedquery(self, config: dict) -> dict:
+        """
+        Creates a new RelatedQuery.
+        """
+        url = f"{self.base_url}/api/admin/relatedquery/setting"
+        return self.send_request(Action.CREATE, url, json=config)
+
+    def update_relatedquery(self, config: dict) -> dict:
+        """
+        Updates an existing RelatedQuery.
+        """
+        url = f"{self.base_url}/api/admin/relatedquery/setting"
+        return self.send_request(Action.EDIT, url, json=config)
+
+    def delete_relatedquery(self, config_id: str) -> dict:
+        """
+        Deletes a RelatedQuery by ID.
+        """
+        url = f"{self.base_url}/api/admin/relatedquery/setting/{config_id}"
+        return self.send_request(Action.DELETE, url)
+
+    def get_relatedquery(self, config_id: str) -> dict:
+        """
+        Retrieves a RelatedQuery by ID.
+        """
+        url = f"{self.base_url}/api/admin/relatedquery/setting/{config_id}"
+        return self.send_request(Action.GET, url)
+
+    def list_relatedqueries(self, page: int = 1, size: int = 100) -> dict:
+        """
+        Retrieves a list of RelatedQueries.
+        """
+        url = f"{self.base_url}/api/admin/relatedquery/settings"
+        params = {"page": page, "size": size}
+        return self.send_request(Action.LIST, url, params=params)

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -26,6 +26,7 @@ from fessctl.commands.pathmap import pathmap_app
 # from fessctl.commands.plugin  import plugin_app
 from fessctl.commands.role import role_app
 from fessctl.commands.relatedcontent import relatedcontent_app
+from fessctl.commands.relatedquery import relatedquery_app
 # from fessctl.commands.searchlist import searchlist_app
 from fessctl.commands.scheduler import scheduler_app
 # from fessctl.commands.stats import stats_app
@@ -60,6 +61,7 @@ app.add_typer(pathmap_app, name="pathmap")
 # app.add_typer(plugin_app, name="plugin")
 app.add_typer(role_app, name="role")
 app.add_typer(relatedcontent_app, name="relatedcontent")
+app.add_typer(relatedquery_app, name="relatedquery")
 # app.add_typer(searchlist_app, name="searchlist")
 app.add_typer(scheduler_app, name="scheduler")
 # app.add_typer(stats_app, name="stats")

--- a/src/fessctl/commands/relatedquery.py
+++ b/src/fessctl/commands/relatedquery.py
@@ -1,0 +1,262 @@
+import datetime
+import json
+from typing import List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from fessctl.api.client import FessAPIClient
+from fessctl.utils import to_utc_iso8601
+
+relatedquery_app = typer.Typer()
+
+
+@relatedquery_app.command("create")
+def create_relatedquery(
+    term: str = typer.Option(..., "--term", help="Search term"),
+    queries: str = typer.Option(..., "--queries", help="Query expressions"),
+    version_no: int = typer.Option(..., "--version-no", help="Version number"),
+    virtual_host: Optional[str] = typer.Option(
+        None, "--virtual-host", help="Virtual host"),
+    created_by: str = typer.Option("admin", "--created-by", help="Created by"),
+    created_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--created-time",
+        help="Created time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Create a new RelatedQuery.
+    """
+    client = FessAPIClient()
+
+    config = {
+        "crud_mode": 1,
+        "term": term,
+        "queries": queries,
+        "version_no": version_no,
+        "created_by": created_by,
+        "created_time": created_time,
+    }
+
+    if virtual_host:
+        config["virtual_host"] = virtual_host
+
+    result = client.create_relatedquery(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            relatedquery_id = result.get("response", {}).get("id", "")
+            typer.secho(
+                f"RelatedQuery '{relatedquery_id}' created successfully.", fg=typer.colors.GREEN)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to create RelatedQuery. {message} Status code: {status}", fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@relatedquery_app.command("update")
+def update_relatedquery(
+    config_id: str = typer.Argument(..., help="RelatedQuery ID"),
+    term: Optional[str] = typer.Option(None, "--term", help="Search term"),
+    queries: Optional[str] = typer.Option(
+        None, "--queries", help="Query expressions"),
+    virtual_host: Optional[str] = typer.Option(
+        None, "--virtual-host", help="Virtual host"),
+    updated_by: str = typer.Option("admin", "--updated-by", help="Updated by"),
+    updated_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--updated-time", help="Updated time in milliseconds (UTC)"
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Update an existing RelatedQuery.
+    """
+    client = FessAPIClient()
+    result = client.get_relatedquery(config_id)
+
+    if result.get("response", {}).get("status", 1) != 0:
+        message: str = result.get("response", {}).get("message", "")
+        typer.secho(
+            f"RelatedQuery with ID '{config_id}' not found. {message}",
+            fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    config = result.get("response", {}).get("setting", {})
+    config["crud_mode"] = 2
+    config["id"] = config_id
+    config["updated_by"] = updated_by
+    config["updated_time"] = updated_time
+
+    if term is not None:
+        config["term"] = term
+    if queries is not None:
+        config["queries"] = queries
+    if virtual_host is not None:
+        config["virtual_host"] = virtual_host
+
+    result = client.update_relatedquery(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"RelatedQuery '{config_id}' updated successfully.",
+                fg=typer.colors.GREEN)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to update RelatedQuery. {message} Status code: {status}",
+                fg=typer.colors.RED)
+            raise typer.Exit(code=status)
+
+
+@relatedquery_app.command("delete")
+def delete_relatedquery(
+    config_id: str = typer.Argument(..., help="RelatedQuery ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Delete a RelatedQuery by ID.
+    """
+    client = FessAPIClient()
+    result = client.delete_relatedquery(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"RelatedQuery '{config_id}' deleted successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to delete RelatedQuery. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@relatedquery_app.command("get")
+def get_relatedquery(
+    config_id: str = typer.Argument(..., help="RelatedQuery ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Retrieve a RelatedQuery by ID.
+    """
+    client = FessAPIClient()
+    result = client.get_relatedquery(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            relatedquery = result.get("response", {}).get("setting", {})
+            console = Console()
+            table = Table(
+                title=f"RelatedQuery Details: {relatedquery.get('id', '-')}")
+            table.add_column("Field", style="cyan", no_wrap=True)
+            table.add_column("Value", style="magenta")
+
+            table.add_row("id", str(relatedquery.get("id", "-")))
+            table.add_row("term", str(relatedquery.get("term", "-")))
+            table.add_row("queries", str(relatedquery.get("queries", "-")))
+            table.add_row("virtual_host", str(
+                relatedquery.get("virtual_host", "-")))
+            table.add_row("version_no", str(
+                relatedquery.get("version_no", "-")))
+            table.add_row("crud_mode", str(relatedquery.get("crud_mode", "-")))
+            table.add_row("updated_by", str(
+                relatedquery.get("updated_by", "-")))
+            table.add_row("updated_time", to_utc_iso8601(
+                relatedquery.get("updated_time")))
+            table.add_row("created_by", str(
+                relatedquery.get("created_by", "-")))
+            table.add_row("created_time", to_utc_iso8601(
+                relatedquery.get("created_time")))
+
+            console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to retrieve RelatedQuery. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@relatedquery_app.command("list")
+def list_relatedqueries(
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    size: int = typer.Option(100, "--size", "-s", help="Page size"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    List RelatedQueries.
+    """
+    client = FessAPIClient()
+    result = client.list_relatedqueries(page=page, size=size)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            relatedqueries = result.get("response", {}).get("settings", [])
+            if len(relatedqueries) == 0:
+                typer.secho("No RelatedQueries found.",
+                            fg=typer.colors.YELLOW)
+            else:
+                console = Console()
+                table = Table(title="RelatedQueries")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("TERM", style="magenta")
+                table.add_column("QUERIES", style="green")
+                table.add_column("VIRTUAL HOST", style="blue")
+                table.add_column("VERSION", style="yellow")
+
+                for rq in relatedqueries:
+                    table.add_row(
+                        rq.get("id", "-"),
+                        rq.get("term", "-"),
+                        rq.get("queries", "-"),
+                        rq.get("virtual_host", "-"),
+                        str(rq.get("version_no", "-")),
+                    )
+                console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to list RelatedQueries. {message} Status code: {status}",
+                fg=typer.colors.RED)
+            raise typer.Exit(code=status)


### PR DESCRIPTION
This pull request introduces a new feature to manage "RelatedQuery" entities in the `fessctl` CLI tool. It includes API client methods, CLI commands, and integration into the main application. The most important changes are grouped below by theme.

### API Client Enhancements:
* Added methods in `src/fessctl/api/client.py` to support CRUD operations for RelatedQuery: `create_relatedquery`, `update_relatedquery`, `delete_relatedquery`, `get_relatedquery`, and `list_relatedqueries`. These methods interact with the `/api/admin/relatedquery/setting` and `/api/admin/relatedquery/settings` endpoints.

### CLI Commands for RelatedQuery:
* Introduced a new CLI module, `src/fessctl/commands/relatedquery.py`, which defines commands for managing RelatedQuery entities (`create`, `update`, `delete`, `get`, `list`). These commands provide options for specifying parameters, output formats (text, JSON, YAML), and user-friendly error handling.

### Application Integration:
* Registered the new `relatedquery_app` with the main CLI application in `src/fessctl/cli.py`, enabling `relatedquery` as a top-level command. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R29) [[2]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R64)