### PR TITLE
Add reqheader

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -973,3 +973,41 @@ class FessAPIClient:
         url = f"{self.base_url}/api/admin/relatedquery/settings"
         params = {"page": page, "size": size}
         return self.send_request(Action.LIST, url, params=params)
+
+    # ReqHeader APIs
+
+    def create_reqheader(self, config: dict) -> dict:
+        """
+        Creates a new ReqHeader.
+        """
+        url = f"{self.base_url}/api/admin/reqheader/setting"
+        return self.send_request(Action.CREATE, url, json=config)
+
+    def update_reqheader(self, config: dict) -> dict:
+        """
+        Updates an existing ReqHeader.
+        """
+        url = f"{self.base_url}/api/admin/reqheader/setting"
+        return self.send_request(Action.EDIT, url, json=config)
+
+    def delete_reqheader(self, config_id: str) -> dict:
+        """
+        Deletes a ReqHeader by ID.
+        """
+        url = f"{self.base_url}/api/admin/reqheader/setting/{config_id}"
+        return self.send_request(Action.DELETE, url)
+
+    def get_reqheader(self, config_id: str) -> dict:
+        """
+        Retrieves a ReqHeader by ID.
+        """
+        url = f"{self.base_url}/api/admin/reqheader/setting/{config_id}"
+        return self.send_request(Action.GET, url)
+
+    def list_reqheaders(self, page: int = 1, size: int = 100) -> dict:
+        """
+        Retrieves a list of ReqHeaders.
+        """
+        url = f"{self.base_url}/api/admin/reqheader/settings"
+        params = {"page": page, "size": size}
+        return self.send_request(Action.LIST, url, params=params)

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -27,6 +27,7 @@ from fessctl.commands.pathmap import pathmap_app
 from fessctl.commands.role import role_app
 from fessctl.commands.relatedcontent import relatedcontent_app
 from fessctl.commands.relatedquery import relatedquery_app
+from fessctl.commands.reqheader import reqheader_app
 # from fessctl.commands.searchlist import searchlist_app
 from fessctl.commands.scheduler import scheduler_app
 # from fessctl.commands.stats import stats_app
@@ -62,6 +63,7 @@ app.add_typer(pathmap_app, name="pathmap")
 app.add_typer(role_app, name="role")
 app.add_typer(relatedcontent_app, name="relatedcontent")
 app.add_typer(relatedquery_app, name="relatedquery")
+app.add_typer(reqheader_app, name="reqheader")
 # app.add_typer(searchlist_app, name="searchlist")
 app.add_typer(scheduler_app, name="scheduler")
 # app.add_typer(stats_app, name="stats")

--- a/src/fessctl/commands/reqheader.py
+++ b/src/fessctl/commands/reqheader.py
@@ -67,7 +67,7 @@ def create_reqheader(
 
 @reqheader_app.command("update")
 def update_reqheader(
-    config_id: str = typer.Argument(..., help="ReqHeader ID"),
+    reqheader_id: str = typer.Argument(..., help="ReqHeader ID"),
     name: Optional[str] = typer.Option(
         None, "--name", help="Name of the request header"),
     value: Optional[str] = typer.Option(
@@ -87,11 +87,11 @@ def update_reqheader(
     Update an existing ReqHeader.
     """
     client = FessAPIClient()
-    result = client.get_reqheader(config_id)
+    result = client.get_reqheader(reqheader_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
         typer.secho(
-            f"ReqHeader '{config_id}' not found. {message}", fg=typer.colors.RED)
+            f"ReqHeader '{reqheader_id}' not found. {message}", fg=typer.colors.RED)
         raise typer.Exit(code=1)
 
     config = result.get("response", {}).get("setting", {})
@@ -116,7 +116,7 @@ def update_reqheader(
     else:
         if status == 0:
             typer.secho(
-                f"ReqHeader '{config_id}' updated successfully.", fg=typer.colors.GREEN)
+                f"ReqHeader '{reqheader_id}' updated successfully.", fg=typer.colors.GREEN)
         else:
             message = result.get("response", {}).get("message", "")
             typer.secho(
@@ -128,7 +128,7 @@ def update_reqheader(
 
 @reqheader_app.command("delete")
 def delete_reqheader(
-    config_id: str = typer.Argument(..., help="ReqHeader ID"),
+    reqheader_id: str = typer.Argument(..., help="ReqHeader ID"),
     output: str = typer.Option(
         "text", "--output", "-o", help="Output format (text, json, yaml)"),
 ):
@@ -136,7 +136,7 @@ def delete_reqheader(
     Delete a ReqHeader by ID.
     """
     client = FessAPIClient()
-    result = client.delete_reqheader(config_id)
+    result = client.delete_reqheader(reqheader_id)
     status = result.get("response", {}).get("status", 1)
 
     if output == "json":
@@ -146,7 +146,7 @@ def delete_reqheader(
     else:
         if status == 0:
             typer.secho(
-                f"ReqHeader '{config_id}' deleted successfully.",
+                f"ReqHeader '{reqheader_id}' deleted successfully.",
                 fg=typer.colors.GREEN,
             )
         else:
@@ -160,7 +160,7 @@ def delete_reqheader(
 
 @reqheader_app.command("get")
 def get_reqheader(
-    config_id: str = typer.Argument(..., help="ReqHeader ID"),
+    reqheader_id: str = typer.Argument(..., help="ReqHeader ID"),
     output: str = typer.Option(
         "text", "--output", "-o", help="Output format: text, json, yaml"),
 ):
@@ -168,7 +168,7 @@ def get_reqheader(
     Retrieve a ReqHeader by ID.
     """
     client = FessAPIClient()
-    result = client.get_reqheader(config_id)
+    result = client.get_reqheader(reqheader_id)
     status = result.get("response", {}).get("status", 1)
 
     if output == "json":

--- a/src/fessctl/commands/reqheader.py
+++ b/src/fessctl/commands/reqheader.py
@@ -1,0 +1,264 @@
+import datetime
+import json
+from typing import List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from fessctl.api.client import FessAPIClient
+from fessctl.utils import to_utc_iso8601
+
+reqheader_app = typer.Typer()
+
+
+@reqheader_app.command("create")
+def create_reqheader(
+    name: str = typer.Option(..., "--name", help="Name of the request header"),
+    value: str = typer.Option(..., "--value",
+                              help="Value of the request header"),
+    web_config_id: str = typer.Option(...,
+                                      "--web-config-id", help="Web config ID"),
+    created_by: str = typer.Option("admin", "--created-by", help="Created by"),
+    created_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--created-time",
+        help="Created time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"
+    ),
+):
+    """
+    Create a new ReqHeader.
+    """
+    client = FessAPIClient()
+
+    config = {
+        "crud_mode": 1,           # constant for create
+        "name": name,             # required, max length 100
+        "value": value,           # required, max length 1000
+        "web_config_id": web_config_id,  # required, max length 1000
+        "created_by": created_by,         # optional, max length 1000
+        "created_time": created_time,     # UTC milliseconds
+    }
+
+    result = client.create_reqheader(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            reqheader_id = result.get("response", {}).get("id", "")
+            typer.secho(
+                f"ReqHeader '{reqheader_id}' created successfully.", fg=typer.colors.GREEN)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to create ReqHeader. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@reqheader_app.command("update")
+def update_reqheader(
+    config_id: str = typer.Argument(..., help="ReqHeader ID"),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Name of the request header"),
+    value: Optional[str] = typer.Option(
+        None, "--value", help="Value of the request header"),
+    web_config_id: Optional[str] = typer.Option(
+        None, "--web-config-id", help="Web config ID"),
+    updated_by: str = typer.Option("admin", "--updated-by", help="Updated by"),
+    updated_time: int = typer.Option(
+        int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000),
+        "--updated-time",
+        help="Updated time in milliseconds (UTC)",
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Update an existing ReqHeader.
+    """
+    client = FessAPIClient()
+    result = client.get_reqheader(config_id)
+    if result.get("response", {}).get("status", 1) != 0:
+        message: str = result.get("response", {}).get("message", "")
+        typer.secho(
+            f"ReqHeader '{config_id}' not found. {message}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    config = result.get("response", {}).get("setting", {})
+    config["crud_mode"] = 2
+    config["updated_by"] = updated_by
+    config["updated_time"] = updated_time
+
+    if name is not None:
+        config["name"] = name
+    if value is not None:
+        config["value"] = value
+    if web_config_id is not None:
+        config["web_config_id"] = web_config_id
+
+    result = client.update_reqheader(config)
+    status: int = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"ReqHeader '{config_id}' updated successfully.", fg=typer.colors.GREEN)
+        else:
+            message = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to update ReqHeader. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@reqheader_app.command("delete")
+def delete_reqheader(
+    config_id: str = typer.Argument(..., help="ReqHeader ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format (text, json, yaml)"),
+):
+    """
+    Delete a ReqHeader by ID.
+    """
+    client = FessAPIClient()
+    result = client.delete_reqheader(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            typer.secho(
+                f"ReqHeader '{config_id}' deleted successfully.",
+                fg=typer.colors.GREEN,
+            )
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to delete ReqHeader. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@reqheader_app.command("get")
+def get_reqheader(
+    config_id: str = typer.Argument(..., help="ReqHeader ID"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"),
+):
+    """
+    Retrieve a ReqHeader by ID.
+    """
+    client = FessAPIClient()
+    result = client.get_reqheader(config_id)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            reqheader = result.get("response", {}).get("setting", {})
+            console = Console()
+            table = Table(
+                title=f"ReqHeader Details: {reqheader.get('id', '-')}")
+            table.add_column("Field", style="cyan", no_wrap=True)
+            table.add_column("Value", style="magenta")
+
+            # Output fields (ReqHeader public name fields only)
+            table.add_row("id", str(reqheader.get("id", "-")))
+            table.add_row("updated_by", str(reqheader.get("updated_by", "-")))
+            table.add_row("updated_time", to_utc_iso8601(
+                reqheader.get("updated_time")))
+            table.add_row("version_no", str(reqheader.get("version_no", "-")))
+            table.add_row("crud_mode", str(reqheader.get("crud_mode", "-")))
+            table.add_row("hostname", str(reqheader.get("hostname", "-")))
+            table.add_row("port", str(reqheader.get("port", "-")))
+            table.add_row("auth_realm", str(reqheader.get("auth_realm", "-")))
+            table.add_row("protocol_scheme", str(
+                reqheader.get("protocol_scheme", "-")))
+            table.add_row("username", str(reqheader.get("username", "-")))
+            table.add_row("password", str(reqheader.get("password", "-")))
+            table.add_row("parameters", str(reqheader.get("parameters", "-")))
+            table.add_row("web_config_id", str(
+                reqheader.get("web_config_id", "-")))
+            table.add_row("created_by", str(reqheader.get("created_by", "-")))
+            table.add_row("created_time", to_utc_iso8601(
+                reqheader.get("created_time")))
+
+            console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to retrieve ReqHeader. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)
+
+
+@reqheader_app.command("list")
+def list_reqheaders(
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    size: int = typer.Option(100, "--size", "-s", help="Page size"),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text, json, yaml"
+    ),
+):
+    """
+    List ReqHeaders.
+    """
+    client = FessAPIClient()
+    result = client.list_reqheaders(page=page, size=size)
+    status = result.get("response", {}).get("status", 1)
+
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+    elif output == "yaml":
+        typer.echo(yaml.dump(result))
+    else:
+        if status == 0:
+            reqheaders = result.get("response", {}).get("settings", [])
+            if not reqheaders:
+                typer.secho("No ReqHeaders found.", fg=typer.colors.YELLOW)
+            else:
+                console = Console()
+                table = Table(title="ReqHeaders")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("NAME", style="cyan")
+                table.add_column("VALUE", style="cyan")
+                table.add_column("WEB_CONFIG_ID", style="cyan")
+
+                for rh in reqheaders:
+                    table.add_row(
+                        rh.get("id", "-"),
+                        rh.get("name", "-"),
+                        rh.get("value", "-"),
+                        rh.get("web_config_id", "-"),
+                    )
+                console.print(table)
+        else:
+            message: str = result.get("response", {}).get("message", "")
+            typer.secho(
+                f"Failed to list ReqHeaders. {message} Status code: {status}",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=status)


### PR DESCRIPTION
This pull request introduces a new feature to manage "ReqHeader" configurations in the `fessctl` CLI. It includes API client methods, CLI commands, and integration into the main application. Below are the most important changes:

### API Client Enhancements:
* Added new methods to `FessAPIClient` for creating, updating, deleting, retrieving, and listing ReqHeaders (`create_reqheader`, `update_reqheader`, `delete_reqheader`, `get_reqheader`, `list_reqheaders`) in `src/fessctl/api/client.py`.

### CLI Command Additions:
* Introduced a new `reqheader` command group in `src/fessctl/commands/reqheader.py` with the following subcommands:
  - [`create`](diffhunk://#diff-1785dac8f7385cf429d60495a3d91eec62e543b01d0a8a79f8df107b6ca9d24fR1-R264): Create a new ReqHeader with options for name, value, web config ID, and more.
  - [`update`](diffhunk://#diff-1785dac8f7385cf429d60495a3d91eec62e543b01d0a8a79f8df107b6ca9d24fR1-R264): Update an existing ReqHeader by ID with optional fields like name, value, and web config ID.
  - [`delete`](diffhunk://#diff-1785dac8f7385cf429d60495a3d91eec62e543b01d0a8a79f8df107b6ca9d24fR1-R264): Delete a ReqHeader by ID.
  - [`get`](diffhunk://#diff-1785dac8f7385cf429d60495a3d91eec62e543b01d0a8a79f8df107b6ca9d24fR1-R264): Retrieve details of a ReqHeader by ID.
  - [`list`](diffhunk://#diff-1785dac8f7385cf429d60495a3d91eec62e543b01d0a8a79f8df107b6ca9d24fR1-R264): List all ReqHeaders with pagination support.

### CLI Integration:
* Registered the new `reqheader` command group in the main CLI application in `src/fessctl/cli.py`. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R30) [[2]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5R66)