### PR TITLE
Refactor FessAPIClient Initialization to Accept Settings via Constructor Injection

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 import httpx
 
-from fessctl.config.settings import settings
+from fessctl.config.settings import Settings
 
 
 class Action(Enum):
@@ -17,7 +17,7 @@ class Action(Enum):
 
 
 class FessAPIClient:
-    def __init__(self):
+    def __init__(self, settings: Settings):
         self.base_url = settings.fess_endpoint
         self.admin_api_headers = {
             "Authorization": f"Bearer {settings.access_token}",

--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -4,6 +4,7 @@ import typer
 import yaml
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.commands.accesstoken import accesstoken_app
 # from fessctl.commands.backup import backup_app
 from fessctl.commands.badword import badword_app
@@ -84,7 +85,7 @@ def ping(
     """
     Check the health status of the Fess server.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     try:
         result = client.ping()
         status = result.get("data", {}).get("status", "unknown")

--- a/src/fessctl/commands/accesstoken.py
+++ b/src/fessctl/commands/accesstoken.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 accesstoken_app = typer.Typer()
@@ -16,7 +17,8 @@ accesstoken_app = typer.Typer()
 @accesstoken_app.command("create")
 def create_accesstoken(
     name: str = typer.Option(..., "--name", help="AccessToken name"),
-    token: Optional[str] = typer.Option(None, "--token", help="Access token string"),
+    token: Optional[str] = typer.Option(
+        None, "--token", help="Access token string"),
     permissions: Optional[List[str]] = typer.Option(
         [], "--permission", help="Access permissions"
     ),
@@ -41,7 +43,7 @@ def create_accesstoken(
     """
     Create a new AccessToken.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())(Settings())
 
     config = {
         "crud_mode": 1,
@@ -80,8 +82,10 @@ def create_accesstoken(
 @accesstoken_app.command("update")
 def update_accesstoken(
     accesstoken_id: str = typer.Argument(..., help="AccessToken ID"),
-    name: Optional[str] = typer.Option(None, "--name", help="AccessToken name"),
-    token: Optional[str] = typer.Option(None, "--token", help="Access token string"),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="AccessToken name"),
+    token: Optional[str] = typer.Option(
+        None, "--token", help="Access token string"),
     permissions: Optional[List[str]] = typer.Option(
         None, "--permission", help="Access permissions"
     ),
@@ -104,7 +108,7 @@ def update_accesstoken(
     """
     Update an existing AccessToken.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_accesstoken(accesstoken_id)
 
     if result.get("response", {}).get("status", 1) != 0:
@@ -164,7 +168,7 @@ def delete_accesstoken(
     """
     Delete a AccessToken by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_accesstoken(accesstoken_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -197,7 +201,7 @@ def get_accesstoken(
     """
     Retrieve an AccessToken by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_accesstoken(accesstoken_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -209,23 +213,29 @@ def get_accesstoken(
         if status == 0:
             accesstoken = result.get("response", {}).get("setting", {})
             console = Console()
-            table = Table(title=f"AccessToken Details: {accesstoken.get('name', '-')}")
+            table = Table(
+                title=f"AccessToken Details: {accesstoken.get('name', '-')}")
             table.add_column("Field", style="cyan", no_wrap=True)
             table.add_column("Value", style="magenta")
 
             # Output each field according to the latest AccessToken schema
             table.add_row("id", str(accesstoken.get("id", "-")))
-            table.add_row("updated_by", str(accesstoken.get("updated_by", "-")))
+            table.add_row("updated_by", str(
+                accesstoken.get("updated_by", "-")))
             table.add_row(
                 "updated_time", to_utc_iso8601(accesstoken.get("updated_time"))
             )
-            table.add_row("version_no", str(accesstoken.get("version_no", "-")))
+            table.add_row("version_no", str(
+                accesstoken.get("version_no", "-")))
             table.add_row("name", str(accesstoken.get("name", "-")))
             table.add_row("token", str(accesstoken.get("token", "-")))
-            table.add_row("permissions", str(accesstoken.get("permissions", "-")))
-            table.add_row("parameter_name", str(accesstoken.get("parameter_name", "-")))
+            table.add_row("permissions", str(
+                accesstoken.get("permissions", "-")))
+            table.add_row("parameter_name", str(
+                accesstoken.get("parameter_name", "-")))
             table.add_row("expires", str(accesstoken.get("expires", "-")))
-            table.add_row("created_by", str(accesstoken.get("created_by", "-")))
+            table.add_row("created_by", str(
+                accesstoken.get("created_by", "-")))
             table.add_row(
                 "created_time", to_utc_iso8601(accesstoken.get("created_time"))
             )
@@ -251,7 +261,7 @@ def list_accesstokens(
     """
     List AccessTokens.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_accesstokens(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/accesstoken.py
+++ b/src/fessctl/commands/accesstoken.py
@@ -43,7 +43,7 @@ def create_accesstoken(
     """
     Create a new AccessToken.
     """
-    client = FessAPIClient(Settings())(Settings())
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,

--- a/src/fessctl/commands/badword.py
+++ b/src/fessctl/commands/badword.py
@@ -31,7 +31,7 @@ def create_badword(
     """
     Create a new BadWord.
     """
-    client = FessAPIClient(Settings())(Settings())
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,

--- a/src/fessctl/commands/badword.py
+++ b/src/fessctl/commands/badword.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 badword_app = typer.Typer()
@@ -30,7 +31,7 @@ def create_badword(
     """
     Create a new BadWord.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())(Settings())
 
     config = {
         "crud_mode": 1,
@@ -75,7 +76,7 @@ def update_badword(
     """
     Update an existing BadWord.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_badword(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -124,7 +125,7 @@ def delete_badword(
     """
     Delete a BadWord by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_badword(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -156,7 +157,7 @@ def get_badword(
     """
     Retrieve a BadWord by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_badword(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -205,7 +206,7 @@ def list_badwords(
     """
     List BadWords.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_badwords(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/boostdoc.py
+++ b/src/fessctl/commands/boostdoc.py
@@ -33,7 +33,7 @@ def create_boostdoc(
     """
     Create a new BoostDoc.
     """
-    client = FessAPIClient(Settings())(Settings())
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,

--- a/src/fessctl/commands/boostdoc.py
+++ b/src/fessctl/commands/boostdoc.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 boostdoc_app = typer.Typer()
@@ -32,7 +33,7 @@ def create_boostdoc(
     """
     Create a new BoostDoc.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())(Settings())
 
     config = {
         "crud_mode": 1,
@@ -83,7 +84,7 @@ def update_boostdoc(
     """
     Update an existing BoostDoc.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_boostdoc(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -130,7 +131,7 @@ def delete_boostdoc(
     """
     Delete a BoostDoc by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_boostdoc(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -162,7 +163,7 @@ def get_boostdoc(
     """
     Retrieve a BoostDoc by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_boostdoc(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -211,7 +212,7 @@ def list_boostdocs(
     """
     List BoostDocs.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_boostdocs(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/crawlinginfo.py
+++ b/src/fessctl/commands/crawlinginfo.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 crawlinginfo_app = typer.Typer()
@@ -21,7 +22,7 @@ def delete_crawlinginfo(
     """
     Delete a CrawlingInfo by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_crawlinginfo(crawlinginfo_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -54,7 +55,7 @@ def get_crawlinginfo(
     """
     Retrieve a CrawlingInfo by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_crawlinginfo(crawlinginfo_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -74,9 +75,11 @@ def get_crawlinginfo(
 
             # output all fields according to new schema
             table.add_row("id", str(crawlinginfo.get("id", "-")))
-            table.add_row("session_id", str(crawlinginfo.get("session_id", "-")))
+            table.add_row("session_id", str(
+                crawlinginfo.get("session_id", "-")))
             table.add_row(
-                "created_time", to_utc_iso8601(crawlinginfo.get("created_time"))
+                "created_time", to_utc_iso8601(
+                    crawlinginfo.get("created_time"))
             )
             # TODO add missing fields
 
@@ -101,7 +104,7 @@ def list_crawlinginfos(
     """
     List CrawlingInfos.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_crawlinginfos(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
     if output == "json":

--- a/src/fessctl/commands/dataconfig.py
+++ b/src/fessctl/commands/dataconfig.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 dataconfig_app = typer.Typer()
@@ -43,7 +44,7 @@ def create_dataconfig(
     """
     Create a new DataConfig.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -114,7 +115,7 @@ def update_dataconfig(
     """
     Update an existing DataConfig.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_dataconfig(config_id)
 
     if result.get("response", {}).get("status", 1) != 0:
@@ -180,7 +181,7 @@ def delete_dataconfig(
     """
     Delete a DataConfig by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_dataconfig(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -212,7 +213,7 @@ def get_dataconfig(
     """
     Retrieve a DataConfig by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_dataconfig(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -275,7 +276,7 @@ def list_dataconfigs(
     """
     List DataConfigs.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_dataconfigs(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/duplicatehost.py
+++ b/src/fessctl/commands/duplicatehost.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 duplicatehost_app = typer.Typer()
@@ -15,7 +16,8 @@ duplicatehost_app = typer.Typer()
 
 @duplicatehost_app.command("create")
 def create_duplicatehost(
-    regular_name: str = typer.Option(..., "--regular-name", help="Regular host name"),
+    regular_name: str = typer.Option(...,
+                                     "--regular-name", help="Regular host name"),
     duplicate_host_name: str = typer.Option(
         ..., "--duplicate-host-name", help="Duplicate host name"
     ),
@@ -35,7 +37,7 @@ def create_duplicatehost(
     """
     Create a new DuplicateHost.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -93,7 +95,7 @@ def update_duplicatehost(
     """
     Update an existing DuplicateHost.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_duplicatehost(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -147,7 +149,7 @@ def delete_duplicatehost(
     """
     Delete a DuplicateHost by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_duplicatehost(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -180,7 +182,7 @@ def get_duplicatehost(
     """
     Retrieve a DuplicateHost by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_duplicatehost(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -200,21 +202,29 @@ def get_duplicatehost(
 
             # 正しい public name ベースのフィールドのみを表示
             table.add_row("id", str(duplicatehost.get("id", "-")))
-            table.add_row("regular_name", str(duplicatehost.get("regular_name", "-")))
+            table.add_row("regular_name", str(
+                duplicatehost.get("regular_name", "-")))
             table.add_row(
                 "duplicate_host_name",
                 str(duplicatehost.get("duplicate_host_name", "-")),
             )
-            table.add_row("sort_order", str(duplicatehost.get("sort_order", "-")))
-            table.add_row("version_no", str(duplicatehost.get("version_no", "-")))
-            table.add_row("crud_mode", str(duplicatehost.get("crud_mode", "-")))
-            table.add_row("updated_by", str(duplicatehost.get("updated_by", "-")))
+            table.add_row("sort_order", str(
+                duplicatehost.get("sort_order", "-")))
+            table.add_row("version_no", str(
+                duplicatehost.get("version_no", "-")))
+            table.add_row("crud_mode", str(
+                duplicatehost.get("crud_mode", "-")))
+            table.add_row("updated_by", str(
+                duplicatehost.get("updated_by", "-")))
             table.add_row(
-                "updated_time", to_utc_iso8601(duplicatehost.get("updated_time"))
+                "updated_time", to_utc_iso8601(
+                    duplicatehost.get("updated_time"))
             )
-            table.add_row("created_by", str(duplicatehost.get("created_by", "-")))
+            table.add_row("created_by", str(
+                duplicatehost.get("created_by", "-")))
             table.add_row(
-                "created_time", to_utc_iso8601(duplicatehost.get("created_time"))
+                "created_time", to_utc_iso8601(
+                    duplicatehost.get("created_time"))
             )
 
             console.print(table)
@@ -238,7 +248,7 @@ def list_duplicatehosts(
     """
     List DuplicateHosts.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_duplicatehosts(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/elevateword.py
+++ b/src/fessctl/commands/elevateword.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 elevateword_app = typer.Typer()
@@ -37,7 +38,7 @@ def create_elevateword(
     """
     Create a new ElevateWord.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -102,7 +103,7 @@ def update_elevateword(
     """
     Update an existing ElevateWord.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_elevateword(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -157,7 +158,7 @@ def delete_elevateword(
     """
     Delete an ElevateWord by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_elevateword(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -189,7 +190,7 @@ def get_elevateword(
     """
     Retrieve an ElevateWord by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_elevateword(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -250,7 +251,7 @@ def list_elevatewords(
     """
     List ElevateWords.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_elevatewords(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/fileauth.py
+++ b/src/fessctl/commands/fileauth.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 fileauth_app = typer.Typer()
@@ -40,7 +41,7 @@ def create_fileauth(
     """
     Create a new FileAuth.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -108,7 +109,7 @@ def update_fileauth(
     """
     Update an existing FileAuth.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_fileauth(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -162,7 +163,7 @@ def delete_fileauth(
     """
     Delete a FileAuth by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_fileauth(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -194,7 +195,7 @@ def get_fileauth(
     """
     Retrieve a FileAuth by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_fileauth(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -250,7 +251,7 @@ def list_fileauths(
     """
     List FileAuths.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_fileauths(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/fileconfig.py
+++ b/src/fessctl/commands/fileconfig.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 fileconfig_app = typer.Typer()
@@ -71,7 +72,7 @@ def create_fileconfig(
     """
     Create a new FileConfig.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     config = {
         "crud_mode": 1,
         "name": name,
@@ -179,7 +180,7 @@ def update_fileconfig(
     """
     Update an existing FileConfig.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_fileconfig(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -260,7 +261,7 @@ def delete_fileconfig(
     """
     Delete a FileConfig by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_fileconfig(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -293,7 +294,7 @@ def get_fileconfig(
     """
     Retrieve a FileConfig by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_fileconfig(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -381,7 +382,7 @@ def list_fileconfigs(
     """
     List FileConfigs.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_fileconfigs(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/group.py
+++ b/src/fessctl/commands/group.py
@@ -7,6 +7,8 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
+
 
 # Create a Typer sub-application for group commands
 group_app = typer.Typer()
@@ -28,12 +30,13 @@ def create_group(
     """
     Create a new group in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     attr_dict = {}
     if attributes:
         for attr in attributes:
             if "=" not in attr:
-                typer.secho(f"Invalid attribute format: {attr}", fg=typer.colors.RED)
+                typer.secho(
+                    f"Invalid attribute format: {attr}", fg=typer.colors.RED)
                 raise typer.Exit(code=1)
             key, value = attr.split("=", 1)
             attr_dict[key.strip()] = value.strip()
@@ -77,7 +80,7 @@ def delete_group(
     """
     Delete a group in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.delete_group(group_id=group_id)
@@ -117,7 +120,7 @@ def get_group(
     """
     Retrieve details of a specific group in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.get_group(group_id=group_id)
@@ -172,7 +175,7 @@ def list_groups(
     """
     List groups in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.list_groups(page=page, size=size)

--- a/src/fessctl/commands/joblog.py
+++ b/src/fessctl/commands/joblog.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 joblog_app = typer.Typer()
@@ -20,7 +21,7 @@ def delete_joblog(
     """
     Delete a JobLog by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_joblog(joblog_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -52,7 +53,7 @@ def get_joblog(
     """
     Retrieve a JobLog by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_joblog(joblog_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -102,7 +103,7 @@ def list_joblogs(
     """
     List JobLogs.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_joblogs(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
     if output == "json":

--- a/src/fessctl/commands/keymatch.py
+++ b/src/fessctl/commands/keymatch.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 keymatch_app = typer.Typer()
@@ -36,7 +37,7 @@ def create_keymatch(
     """
     Create a new KeyMatch.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -96,7 +97,7 @@ def update_keymatch(
     """
     Update an existing KeyMatch.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_keymatch(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -149,7 +150,7 @@ def delete_keymatch(
     """
     Delete a KeyMatch by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_keymatch(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -181,7 +182,7 @@ def get_keymatch(
     """
     Retrieve a KeyMatch by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_keymatch(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -231,7 +232,7 @@ def list_keymatchs(
     """
     List KeyMatchs.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_keymatchs(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/labeltype.py
+++ b/src/fessctl/commands/labeltype.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 labeltype_app = typer.Typer()
@@ -39,7 +40,7 @@ def create_labeltype(
     """
     Create a new LabelType.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -112,7 +113,7 @@ def update_labeltype(
     """
     Update an existing LabelType.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_labeltype(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -169,7 +170,7 @@ def delete_labeltype(
     """
     Delete a LabelType by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_labeltype(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -201,7 +202,7 @@ def get_labeltype(
     """
     Retrieve a LabelType by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_labeltype(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -259,7 +260,7 @@ def list_labeltypes(
     """
     List LabelTypes.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_labeltypes(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/pathmap.py
+++ b/src/fessctl/commands/pathmap.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 pathmap_app = typer.Typer()
@@ -34,7 +35,7 @@ def create_path(
     """
     Create a new Path Mapping.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -93,7 +94,7 @@ def update_pathmap(
     """
     Update an existing PathMap.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_pathmap(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -144,7 +145,7 @@ def delete_pathmap(
     """
     Delete a PathMap by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_pathmap(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -176,7 +177,7 @@ def get_pathmap(
     """
     Retrieve a PathMap by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_pathmap(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -229,7 +230,7 @@ def list_pathmaps(
     """
     List PathMaps.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_pathmaps(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/relatedcontent.py
+++ b/src/fessctl/commands/relatedcontent.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 relatedcontent_app = typer.Typer()
@@ -31,7 +32,7 @@ def create_relatedcontent(
     """
     Create a new RelatedContent.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     config = {
         "crud_mode": 1,
         "term": term,
@@ -83,7 +84,7 @@ def update_relatedcontent(
     """
     Update an existing RelatedContent.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_relatedcontent(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -133,7 +134,7 @@ def delete_relatedcontent(
     """
     Delete a RelatedContent by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_relatedcontent(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -165,7 +166,7 @@ def get_relatedcontent(
     """
     Retrieve a RelatedContent by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_relatedcontent(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -223,7 +224,7 @@ def list_relatedcontents(
     """
     List RelatedContents.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_relatedcontents(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/relatedquery.py
+++ b/src/fessctl/commands/relatedquery.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 relatedquery_app = typer.Typer()
@@ -32,7 +33,7 @@ def create_relatedquery(
     """
     Create a new RelatedQuery.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -84,7 +85,7 @@ def update_relatedquery(
     """
     Update an existing RelatedQuery.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_relatedquery(config_id)
 
     if result.get("response", {}).get("status", 1) != 0:
@@ -136,7 +137,7 @@ def delete_relatedquery(
     """
     Delete a RelatedQuery by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_relatedquery(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -168,7 +169,7 @@ def get_relatedquery(
     """
     Retrieve a RelatedQuery by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_relatedquery(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -222,7 +223,7 @@ def list_relatedqueries(
     """
     List RelatedQueries.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_relatedqueries(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/reqheader.py
+++ b/src/fessctl/commands/reqheader.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 reqheader_app = typer.Typer()
@@ -33,7 +34,7 @@ def create_reqheader(
     """
     Create a new ReqHeader.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,           # constant for create
@@ -86,7 +87,7 @@ def update_reqheader(
     """
     Update an existing ReqHeader.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_reqheader(reqheader_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -135,7 +136,7 @@ def delete_reqheader(
     """
     Delete a ReqHeader by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_reqheader(reqheader_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -167,7 +168,7 @@ def get_reqheader(
     """
     Retrieve a ReqHeader by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_reqheader(reqheader_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -226,7 +227,7 @@ def list_reqheaders(
     """
     List ReqHeaders.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_reqheaders(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/role.py
+++ b/src/fessctl/commands/role.py
@@ -7,6 +7,8 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
+
 
 # Create a Typer sub-application for role commands
 role_app = typer.Typer()
@@ -28,12 +30,13 @@ def create_role(
     """
     Create a new role in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     attr_dict = {}
     if attributes:
         for attr in attributes:
             if "=" not in attr:
-                typer.secho(f"Invalid attribute format: {attr}", fg=typer.colors.RED)
+                typer.secho(
+                    f"Invalid attribute format: {attr}", fg=typer.colors.RED)
                 raise typer.Exit(code=1)
             key, value = attr.split("=", 1)
             attr_dict[key.strip()] = value.strip()
@@ -77,7 +80,7 @@ def delete_role(
     """
     Delete a role in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.delete_role(role_id=role_id)
@@ -117,7 +120,7 @@ def get_role(
     """
     Retrieve details of a specific role in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.get_role(role_id=role_id)
@@ -172,7 +175,7 @@ def list_roles(
     """
     List roles in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.list_roles(page=page, size=size)

--- a/src/fessctl/commands/scheduler.py
+++ b/src/fessctl/commands/scheduler.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 scheduler_app = typer.Typer()
@@ -39,7 +40,7 @@ def create_scheduler(
     """
     Create a new Scheduler.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -107,7 +108,7 @@ def update_scheduler(
     """
     Update an existing Scheduler.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_scheduler(scheduler_id)
 
     if result.get("response", {}).get("status", 1) != 0:
@@ -171,7 +172,7 @@ def delete_scheduler(
     """
     Delete a Scheduler by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_scheduler(scheduler_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -203,7 +204,7 @@ def get_scheduler(
     """
     Retrieve a Scheduler by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_scheduler(scheduler_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -263,7 +264,7 @@ def list_schedulers(
     """
     List Schedulers.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_schedulers(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 
@@ -311,7 +312,7 @@ def start_scheduler(
     """
     Start a Scheduler by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.start_scheduler(scheduler_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -343,7 +344,7 @@ def stop_scheduler(
     """
     Stop a Scheduler by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.stop_scheduler(scheduler_id)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/user.py
+++ b/src/fessctl/commands/user.py
@@ -7,6 +7,8 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
+
 
 # Create a Typer sub-application for role commands
 user_app = typer.Typer()
@@ -41,12 +43,13 @@ def create_user_command(
     """
     Create a new user in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     attr_dict = {}
     if attributes:
         for attr in attributes:
             if "=" not in attr:
-                typer.secho(f"Invalid attribute format: {attr}", fg=typer.colors.RED)
+                typer.secho(
+                    f"Invalid attribute format: {attr}", fg=typer.colors.RED)
                 raise typer.Exit(code=1)
             key, value = attr.split("=", 1)
             attr_dict[key.strip()] = value.strip()
@@ -99,7 +102,7 @@ def delete_user_command(
     """
     Delete a user from Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     try:
         result = client.delete_user(user_id)
         status: int = result.get("response", {}).get("status", 1)
@@ -138,7 +141,7 @@ def get_user_command(
     """
     Retrieve details of a user from Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     try:
         result = client.get_user(user_id)
         status: int = result.get("response", {}).get("status", 1)
@@ -151,7 +154,8 @@ def get_user_command(
             if status == 0:
                 user_info = result.get("response", {}).get("setting", {})
                 console = Console()
-                table = Table(title=f"User Details: {user_info.get('name', '-')}")
+                table = Table(
+                    title=f"User Details: {user_info.get('name', '-')}")
                 table.add_column("Field", style="cyan", no_wrap=True)
                 table.add_column("Value", style="magenta")
 
@@ -159,7 +163,8 @@ def get_user_command(
                 table.add_row("Name", user_info.get("name", "-"))
                 table.add_row("Roles", "\n".join(user_info.get("roles", [])))
                 table.add_row("Groups", "\n".join(user_info.get("groups", [])))
-                table.add_row("Attributes", "\n".join(user_info.get("attributes", [])))
+                table.add_row("Attributes", "\n".join(
+                    user_info.get("attributes", [])))
                 table.add_row("Version", str(user_info.get("version_no", "-")))
                 console.print(table)
             else:
@@ -187,7 +192,7 @@ def list_users_command(
     """
     List web authentication users in Fess.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     try:
         result = client.list_users(page=page, size=size)
@@ -236,5 +241,6 @@ def list_users_command(
     except typer.Exit:
         raise
     except Exception as e:
-        typer.secho(f"Error listing web authentication users: {e}", fg=typer.colors.RED)
+        typer.secho(
+            f"Error listing web authentication users: {e}", fg=typer.colors.RED)
         raise typer.Exit(code=1)

--- a/src/fessctl/commands/webauth.py
+++ b/src/fessctl/commands/webauth.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import List, Optional
+from typing import Optional
 
 import typer
 import yaml
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 webauth_app = typer.Typer()
@@ -42,7 +43,7 @@ def create_webauth(
     """
     Create a new WebAuth.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
 
     config = {
         "crud_mode": 1,
@@ -115,7 +116,7 @@ def update_webauth(
     """
     Update an existing WebAuth.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_webauth(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -177,7 +178,7 @@ def delete_webauth(
     """
     Delete a WebAuth by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_webauth(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -209,7 +210,7 @@ def get_webauth(
     """
     Retrieve a WebAuth by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_webauth(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -266,7 +267,7 @@ def list_webauths(
     """
     List WebAuths.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_webauths(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
 

--- a/src/fessctl/commands/webconfig.py
+++ b/src/fessctl/commands/webconfig.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from fessctl.api.client import FessAPIClient
+from fessctl.config.settings import Settings
 from fessctl.utils import to_utc_iso8601
 
 webconfig_app = typer.Typer()
@@ -78,7 +79,7 @@ def create_webconfig(
     """
     Create a new WebConfig.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     config = {
         "crud_mode": 1,
         "name": name,
@@ -192,7 +193,7 @@ def update_webconfig(
     """
     Update an existing WebConfig.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_webconfig(config_id)
     if result.get("response", {}).get("status", 1) != 0:
         message: str = result.get("response", {}).get("message", "")
@@ -275,7 +276,7 @@ def delete_webconfig(
     """
     Delete a WebConfig by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.delete_webconfig(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -307,7 +308,7 @@ def get_webconfig(
     """
     Retrieve a WebConfig by ID.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.get_webconfig(config_id)
     status = result.get("response", {}).get("status", 1)
 
@@ -394,7 +395,7 @@ def list_webconfigs(
     """
     List WebConfigs.
     """
-    client = FessAPIClient()
+    client = FessAPIClient(Settings())
     result = client.list_webconfigs(page=page, size=size)
     status = result.get("response", {}).get("status", 1)
     if output == "json":

--- a/src/fessctl/config/settings.py
+++ b/src/fessctl/config/settings.py
@@ -6,6 +6,3 @@ import os
 class Settings:
     fess_endpoint: str = os.getenv("FESS_ENDPOINT", "http://localhost:8080")
     access_token: str = os.getenv("FESS_ACCESS_TOKEN")
-
-
-settings = Settings()


### PR DESCRIPTION
This pull request refactors the `FessAPIClient` initialization across multiple files in the `fessctl` project to use a `Settings` instance for configuration. Additionally, it includes minor formatting updates to improve code readability.

### Refactoring to use `Settings` for `FessAPIClient` initialization:
* Updated the `FessAPIClient` constructor to accept a `Settings` instance, replacing the previous direct import of `settings`. (`src/fessctl/api/client.py`) [[1]](diffhunk://#diff-0d7f33d722311f9ae4f54023250dda6567bf465538d08c955d70600953f9eeabL6-R6) [[2]](diffhunk://#diff-0d7f33d722311f9ae4f54023250dda6567bf465538d08c955d70600953f9eeabL20-R20)
* Modified various commands (`accesstoken`, `badword`, `boostdoc`, `crawlinginfo`, `dataconfig`) to pass a `Settings` instance to `FessAPIClient` during initialization. This change ensures consistent configuration handling across the CLI commands. [[1]](diffhunk://#diff-d8fda255895ea093c2ad4c91c621058d83496aa55768fdc1aad464b2e71454f5L87-R88) [[2]](diffhunk://#diff-3741d68920e7ee88c5f11e1d97216382a756fde8b107b212556f442e0d4cac7bL44-R46) [[3]](diffhunk://#diff-3ef71b1099d8a2c87c62cea0ebe41107d6060878af8abd21c1d5b85963445cb8L33-R34) [[4]](diffhunk://#diff-39a34ac36f0646ecba775966c5379f2af8fbe7e0dd2023238540de40c503bbccL24-R25) [[5]](diffhunk://#diff-66239c6c8d7571a6914e103d0b8e597afe18674f86684f4d5e3db1257dd764dcL46-R47)

### Code readability improvements:
* Reformatted long argument lists and string concatenations in several functions to improve code clarity. Examples include the `create_accesstoken`, `update_accesstoken`, and `get_accesstoken` functions. [[1]](diffhunk://#diff-3741d68920e7ee88c5f11e1d97216382a756fde8b107b212556f442e0d4cac7bL19-R21) [[2]](diffhunk://#diff-3741d68920e7ee88c5f11e1d97216382a756fde8b107b212556f442e0d4cac7bL212-R238)
* Adjusted table formatting in functions like `get_accesstoken` and `get_crawlinginfo` to align with the latest schema and improve output readability. [[1]](diffhunk://#diff-3741d68920e7ee88c5f11e1d97216382a756fde8b107b212556f442e0d4cac7bL212-R238) [[2]](diffhunk://#diff-39a34ac36f0646ecba775966c5379f2af8fbe7e0dd2023238540de40c503bbccL77-R82)