### PR TITLE
Add version-based logic for HTTP method selection in FessAPIClient

### DIFF
--- a/src/fessctl/config/settings.py
+++ b/src/fessctl/config/settings.py
@@ -6,5 +6,7 @@ import os
 class Settings:
     fess_endpoint: str = field(default_factory=lambda: os.getenv(
         "FESS_ENDPOINT", "http://localhost:8080"))
-    access_token: str = field(
+    access_token: str | None = field(
         default_factory=lambda: os.getenv("FESS_ACCESS_TOKEN", None))
+    fess_version: str = field(
+        default_factory=lambda: os.getenv("FESS_VERSION", "14.19.0"))


### PR DESCRIPTION
This update enhances the FessAPIClient to support dynamic switching between HTTP methods (PUT and POST) based on the Fess version. A _parse_version method was added to extract major and minor version numbers from the FESS_VERSION environment variable. For Fess versions 14 and below, PUT is used for creation and POST for editing. For later versions, the logic is reversed. Additionally, the Settings class now includes a fess_version field. Minor type annotations using | None were also applied for consistency.