### PR TITLE
Fix command error handling and add unit tests for all command modules

### DIFF
--- a/src/fessctl/commands/elevateword.py
+++ b/src/fessctl/commands/elevateword.py
@@ -238,7 +238,7 @@ def get_elevateword(
                 f"Failed to retrieve ElevateWord. {message} Status code: {status}",
                 fg=typer.colors.RED,
             )
-            raise typer.Exit(code=status)
+            raise typer.Exit(code=1)
 
 
 @elevateword_app.command("list")

--- a/src/fessctl/commands/fileauth.py
+++ b/src/fessctl/commands/fileauth.py
@@ -238,7 +238,7 @@ def get_fileauth(
                 f"Failed to retrieve FileAuth. {message} Status code: {status}",
                 fg=typer.colors.RED,
             )
-            raise typer.Exit(code=status)
+            raise typer.Exit(code=1)
 
 
 @fileauth_app.command("list")

--- a/src/fessctl/commands/fileconfig.py
+++ b/src/fessctl/commands/fileconfig.py
@@ -369,7 +369,7 @@ def get_fileconfig(
                 f"Failed to retrieve FileConfig. {message} Status code: {status}",
                 fg=typer.colors.RED,
             )
-            raise typer.Exit(code=status)
+            raise typer.Exit(code=1)
 
 
 @fileconfig_app.command("list")

--- a/src/fessctl/commands/pathmap.py
+++ b/src/fessctl/commands/pathmap.py
@@ -51,7 +51,7 @@ def create_path(
     if user_agent is not None:
         config["user_agent"] = user_agent
 
-    result = client.create_path(config)
+    result = client.create_pathmap(config)
     status: int = result.get("response", {}).get("status", 1)
 
     if output == "json":

--- a/tests/commands/test_accesstoken.py
+++ b/tests/commands/test_accesstoken.py
@@ -1,0 +1,91 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.accesstoken import accesstoken_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_accesstoken_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for AccessTokens.
+    """
+    # 1) Create a new accesstoken
+    unique_name = f"token-{uuid.uuid4().hex[:8]}"
+    result = runner.invoke(
+        accesstoken_app,
+        ["create", "--name", unique_name, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    accesstoken_id = create_resp["response"].get("id")
+    assert accesstoken_id, "No accesstoken ID returned on create"
+
+    # 2) Retrieve the created accesstoken
+    result = runner.invoke(
+        accesstoken_app,
+        ["get", accesstoken_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == accesstoken_id
+    assert setting.get("name") == unique_name
+
+    # 3) Update the accesstoken's permissions
+    result = runner.invoke(
+        accesstoken_app,
+        ["update", accesstoken_id, "--permission", "admin", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated permissions
+    result = runner.invoke(
+        accesstoken_app,
+        ["get", accesstoken_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert "admin" in setting_after.get("permissions", "")
+
+    # 5) List accesstokens and ensure the updated accesstoken appears
+    result = runner.invoke(
+        accesstoken_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert accesstoken_id in ids
+
+    # 6) Delete the accesstoken
+    result = runner.invoke(
+        accesstoken_app,
+        ["delete", accesstoken_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        accesstoken_app,
+        ["get", accesstoken_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve accesstoken" in result.stdout.lower()

--- a/tests/commands/test_badword.py
+++ b/tests/commands/test_badword.py
@@ -1,0 +1,92 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.badword import badword_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_badword_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for BadWords.
+    """
+    # 1) Create a new badword
+    suggest_word = f"badword-{uuid.uuid4().hex[:8]}"
+    result = runner.invoke(
+        badword_app,
+        ["create", "--suggest-word", suggest_word, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    badword_id = create_resp["response"].get("id")
+    assert badword_id, "No badword ID returned on create"
+
+    # 2) Retrieve the created badword
+    result = runner.invoke(
+        badword_app,
+        ["get", badword_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == badword_id
+    assert setting.get("suggest_word") == suggest_word
+
+    # 3) Update the badword's suggest_word
+    new_suggest_word = f"updated-{suggest_word}"
+    result = runner.invoke(
+        badword_app,
+        ["update", badword_id, "--suggest-word", new_suggest_word, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated suggest_word
+    result = runner.invoke(
+        badword_app,
+        ["get", badword_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("suggest_word") == new_suggest_word
+
+    # 5) List badwords and ensure the updated badword appears
+    result = runner.invoke(
+        badword_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert badword_id in ids
+
+    # 6) Delete the badword
+    result = runner.invoke(
+        badword_app,
+        ["delete", badword_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        badword_app,
+        ["get", badword_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve badword" in result.stdout.lower()

--- a/tests/commands/test_boostdoc.py
+++ b/tests/commands/test_boostdoc.py
@@ -1,0 +1,94 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.boostdoc import boostdoc_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_boostdoc_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for BoostDocs.
+    """
+    # 1) Create a new boostdoc
+    url_expr = f"https://example.com/{uuid.uuid4().hex[:8]}"
+    boost_expr = "10.0"
+    sort_order = "0"
+    result = runner.invoke(
+        boostdoc_app,
+        ["create", "--url-expr", url_expr, "--boost-expr", boost_expr, "--sort-order", sort_order, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    boostdoc_id = create_resp["response"].get("id")
+    assert boostdoc_id, "No boostdoc ID returned on create"
+
+    # 2) Retrieve the created boostdoc
+    result = runner.invoke(
+        boostdoc_app,
+        ["get", boostdoc_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == boostdoc_id
+    assert setting.get("url_expr") == url_expr
+
+    # 3) Update the boostdoc's boost_expr
+    new_boost_expr = "20.0"
+    result = runner.invoke(
+        boostdoc_app,
+        ["update", boostdoc_id, "--boost-expr", new_boost_expr, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated boost_expr
+    result = runner.invoke(
+        boostdoc_app,
+        ["get", boostdoc_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("boost_expr") == new_boost_expr
+
+    # 5) List boostdocs and ensure the updated boostdoc appears
+    result = runner.invoke(
+        boostdoc_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert boostdoc_id in ids
+
+    # 6) Delete the boostdoc
+    result = runner.invoke(
+        boostdoc_app,
+        ["delete", boostdoc_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        boostdoc_app,
+        ["get", boostdoc_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve boostdoc" in result.stdout.lower()

--- a/tests/commands/test_dataconfig.py
+++ b/tests/commands/test_dataconfig.py
@@ -1,0 +1,93 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.dataconfig import dataconfig_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_dataconfig_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for DataConfigs.
+    """
+    # 1) Create a new dataconfig
+    unique_name = f"data-{uuid.uuid4().hex[:8]}"
+    handler_name = "csv"
+    result = runner.invoke(
+        dataconfig_app,
+        ["create", "--name", unique_name, "--handler-name", handler_name, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    dataconfig_id = create_resp["response"].get("id")
+    assert dataconfig_id, "No dataconfig ID returned on create"
+
+    # 2) Retrieve the created dataconfig
+    result = runner.invoke(
+        dataconfig_app,
+        ["get", dataconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == dataconfig_id
+    assert setting.get("name") == unique_name
+
+    # 3) Update the dataconfig's description
+    new_description = "test description"
+    result = runner.invoke(
+        dataconfig_app,
+        ["update", dataconfig_id, "--description", new_description, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated description
+    result = runner.invoke(
+        dataconfig_app,
+        ["get", dataconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("description") == new_description
+
+    # 5) List dataconfigs and ensure the updated dataconfig appears
+    result = runner.invoke(
+        dataconfig_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert dataconfig_id in ids
+
+    # 6) Delete the dataconfig
+    result = runner.invoke(
+        dataconfig_app,
+        ["delete", dataconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        dataconfig_app,
+        ["get", dataconfig_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve dataconfig" in result.stdout.lower()

--- a/tests/commands/test_duplicatehost.py
+++ b/tests/commands/test_duplicatehost.py
@@ -1,0 +1,94 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.duplicatehost import duplicatehost_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_duplicatehost_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for DuplicateHosts.
+    """
+    # 1) Create a new duplicatehost
+    regular_name = f"regular-{uuid.uuid4().hex[:8]}.com"
+    duplicate_name = f"duplicate-{uuid.uuid4().hex[:8]}.com"
+    sort_order = "0"
+    result = runner.invoke(
+        duplicatehost_app,
+        ["create", "--regular-name", regular_name, "--duplicate-host-name", duplicate_name, "--sort-order", sort_order, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    duplicatehost_id = create_resp["response"].get("id")
+    assert duplicatehost_id, "No duplicatehost ID returned on create"
+
+    # 2) Retrieve the created duplicatehost
+    result = runner.invoke(
+        duplicatehost_app,
+        ["get", duplicatehost_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == duplicatehost_id
+    assert setting.get("regular_name") == regular_name
+
+    # 3) Update the duplicatehost's sort_order
+    new_sort_order = "10"
+    result = runner.invoke(
+        duplicatehost_app,
+        ["update", duplicatehost_id, "--sort-order", new_sort_order, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated sort_order
+    result = runner.invoke(
+        duplicatehost_app,
+        ["get", duplicatehost_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("sort_order") == int(new_sort_order)
+
+    # 5) List duplicatehosts and ensure the updated duplicatehost appears
+    result = runner.invoke(
+        duplicatehost_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert duplicatehost_id in ids
+
+    # 6) Delete the duplicatehost
+    result = runner.invoke(
+        duplicatehost_app,
+        ["delete", duplicatehost_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        duplicatehost_app,
+        ["get", duplicatehost_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve duplicatehost" in result.stdout.lower()

--- a/tests/commands/test_elevateword.py
+++ b/tests/commands/test_elevateword.py
@@ -1,0 +1,94 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.elevateword import elevateword_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_elevateword_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for ElevateWords.
+    """
+    # 1) Create a new elevateword
+    suggest_word = f"elevate-{uuid.uuid4().hex[:8]}"
+    boost = "10.0"
+    version_no = "1"
+    result = runner.invoke(
+        elevateword_app,
+        ["create", "--suggest-word", suggest_word, "--boost", boost, "--version-no", version_no, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    elevateword_id = create_resp["response"].get("id")
+    assert elevateword_id, "No elevateword ID returned on create"
+
+    # 2) Retrieve the created elevateword
+    result = runner.invoke(
+        elevateword_app,
+        ["get", elevateword_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == elevateword_id
+    assert setting.get("suggest_word") == suggest_word
+
+    # 3) Update the elevateword's boost
+    new_boost = "20.0"
+    result = runner.invoke(
+        elevateword_app,
+        ["update", elevateword_id, "--boost", new_boost, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated boost
+    result = runner.invoke(
+        elevateword_app,
+        ["get", elevateword_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("boost") == float(new_boost)
+
+    # 5) List elevatewords and ensure the updated elevateword appears
+    result = runner.invoke(
+        elevateword_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert elevateword_id in ids
+
+    # 6) Delete the elevateword
+    result = runner.invoke(
+        elevateword_app,
+        ["delete", elevateword_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        elevateword_app,
+        ["get", elevateword_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve elevateword" in result.stdout.lower()

--- a/tests/commands/test_fileauth.py
+++ b/tests/commands/test_fileauth.py
@@ -1,0 +1,110 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.fileauth import fileauth_app
+from fessctl.commands.fileconfig import fileconfig_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+@pytest.fixture(scope="function")
+def temp_fileconfig(runner):
+    """
+    Provides a temporary fileconfig for tests that require one.
+    """
+    unique_name = f"temp-fileconfig-{uuid.uuid4().hex[:8]}"
+    path = f"file:/{unique_name}/"
+    result = runner.invoke(
+        fileconfig_app,
+        ["create", "--name", unique_name, "--path", path, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Failed to create temp fileconfig: {result.stdout}"
+    fileconfig_id = json.loads(result.stdout)["response"]["id"]
+    yield fileconfig_id
+    runner.invoke(fileconfig_app, ["delete", fileconfig_id])
+
+
+def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for FileAuths.
+    """
+    # 1) Create a new fileauth
+    username = f"user-{uuid.uuid4().hex[:8]}"
+    result = runner.invoke(
+        fileauth_app,
+        ["create", "--username", username, "--file-config-id", temp_fileconfig, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    fileauth_id = create_resp["response"].get("id")
+    assert fileauth_id, "No fileauth ID returned on create"
+
+    # 2) Retrieve the created fileauth
+    result = runner.invoke(
+        fileauth_app,
+        ["get", fileauth_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == fileauth_id
+    assert setting.get("username") == username
+
+    # 3) Update the fileauth's password
+    new_password = "new_password"
+    result = runner.invoke(
+        fileauth_app,
+        ["update", fileauth_id, "--password", new_password, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated password
+    result = runner.invoke(
+        fileauth_app,
+        ["get", fileauth_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("password") == new_password
+
+    # 5) List fileauths and ensure the updated fileauth appears
+    result = runner.invoke(
+        fileauth_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert fileauth_id in ids
+
+    # 6) Delete the fileauth
+    result = runner.invoke(
+        fileauth_app,
+        ["delete", fileauth_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        fileauth_app,
+        ["get", fileauth_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve fileauth" in result.stdout.lower()

--- a/tests/commands/test_fileconfig.py
+++ b/tests/commands/test_fileconfig.py
@@ -1,0 +1,93 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.fileconfig import fileconfig_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_fileconfig_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for FileConfigs.
+    """
+    # 1) Create a new fileconfig
+    unique_name = f"file-{uuid.uuid4().hex[:8]}"
+    path = f"file:/{unique_name}/"
+    result = runner.invoke(
+        fileconfig_app,
+        ["create", "--name", unique_name, "--path", path, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    fileconfig_id = create_resp["response"].get("id")
+    assert fileconfig_id, "No fileconfig ID returned on create"
+
+    # 2) Retrieve the created fileconfig
+    result = runner.invoke(
+        fileconfig_app,
+        ["get", fileconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == fileconfig_id
+    assert setting.get("name") == unique_name
+
+    # 3) Update the fileconfig's description
+    new_description = "test description"
+    result = runner.invoke(
+        fileconfig_app,
+        ["update", fileconfig_id, "--description", new_description, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated description
+    result = runner.invoke(
+        fileconfig_app,
+        ["get", fileconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("description") == new_description
+
+    # 5) List fileconfigs and ensure the updated fileconfig appears
+    result = runner.invoke(
+        fileconfig_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert fileconfig_id in ids
+
+    # 6) Delete the fileconfig
+    result = runner.invoke(
+        fileconfig_app,
+        ["delete", fileconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        fileconfig_app,
+        ["get", fileconfig_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve fileconfig" in result.stdout.lower()

--- a/tests/commands/test_keymatch.py
+++ b/tests/commands/test_keymatch.py
@@ -1,0 +1,96 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.keymatch import keymatch_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_keymatch_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for KeyMatches.
+    """
+    # 1) Create a new keymatch
+    term = f"term-{uuid.uuid4().hex[:8]}"
+    query = "fess"
+    max_size = "10"
+    boost = "100.0"
+    version_no = "1"
+    result = runner.invoke(
+        keymatch_app,
+        ["create", "--term", term, "--query", query, "--max-size", max_size, "--boost", boost, "--version-no", version_no, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    keymatch_id = create_resp["response"].get("id")
+    assert keymatch_id, "No keymatch ID returned on create"
+
+    # 2) Retrieve the created keymatch
+    result = runner.invoke(
+        keymatch_app,
+        ["get", keymatch_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == keymatch_id
+    assert setting.get("term") == term
+
+    # 3) Update the keymatch's boost
+    new_boost = "200.0"
+    result = runner.invoke(
+        keymatch_app,
+        ["update", keymatch_id, "--boost", new_boost, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated boost
+    result = runner.invoke(
+        keymatch_app,
+        ["get", keymatch_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("boost") == float(new_boost)
+
+    # 5) List keymatches and ensure the updated keymatch appears
+    result = runner.invoke(
+        keymatch_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert keymatch_id in ids
+
+    # 6) Delete the keymatch
+    result = runner.invoke(
+        keymatch_app,
+        ["delete", keymatch_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        keymatch_app,
+        ["get", keymatch_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve keymatch" in result.stdout.lower()

--- a/tests/commands/test_labeltype.py
+++ b/tests/commands/test_labeltype.py
@@ -1,0 +1,94 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.labeltype import labeltype_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_labeltype_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for LabelTypes.
+    """
+    # 1) Create a new labeltype
+    name = f"label-{uuid.uuid4().hex[:8]}"
+    value = f"value_{uuid.uuid4().hex[:8]}"
+    version_no = "1"
+    result = runner.invoke(
+        labeltype_app,
+        ["create", "--name", name, "--value", value, "--version-no", version_no, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    labeltype_id = create_resp["response"].get("id")
+    assert labeltype_id, "No labeltype ID returned on create"
+
+    # 2) Retrieve the created labeltype
+    result = runner.invoke(
+        labeltype_app,
+        ["get", labeltype_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == labeltype_id
+    assert setting.get("name") == name
+
+    # 3) Update the labeltype's name
+    new_name = f"new-{name}"
+    result = runner.invoke(
+        labeltype_app,
+        ["update", labeltype_id, "--name", new_name, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated name
+    result = runner.invoke(
+        labeltype_app,
+        ["get", labeltype_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("name") == new_name
+
+    # 5) List labeltypes and ensure the updated labeltype appears
+    result = runner.invoke(
+        labeltype_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert labeltype_id in ids
+
+    # 6) Delete the labeltype
+    result = runner.invoke(
+        labeltype_app,
+        ["delete", labeltype_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        labeltype_app,
+        ["get", labeltype_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve labeltype" in result.stdout.lower()

--- a/tests/commands/test_pathmap.py
+++ b/tests/commands/test_pathmap.py
@@ -1,0 +1,94 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.pathmap import pathmap_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_pathmap_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for PathMaps.
+    """
+    # 1) Create a new pathmap
+    regex = f"https://{uuid.uuid4().hex[:8]}.com/"
+    process_type = "CRAWLING"
+    replacement = "https://fess.codelibs.org/"
+    result = runner.invoke(
+        pathmap_app,
+        ["create", "--regex", regex, "--process-type", process_type, "--replacement", replacement, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    pathmap_id = create_resp["response"].get("id")
+    assert pathmap_id, "No pathmap ID returned on create"
+
+    # 2) Retrieve the created pathmap
+    result = runner.invoke(
+        pathmap_app,
+        ["get", pathmap_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == pathmap_id
+    assert setting.get("regex") == regex
+
+    # 3) Update the pathmap's replacement
+    new_replacement = "https://www.n2sm.net/"
+    result = runner.invoke(
+        pathmap_app,
+        ["update", pathmap_id, "--replacement", new_replacement, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated replacement
+    result = runner.invoke(
+        pathmap_app,
+        ["get", pathmap_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("replacement") == new_replacement
+
+    # 5) List pathmaps and ensure the updated pathmap appears
+    result = runner.invoke(
+        pathmap_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert pathmap_id in ids
+
+    # 6) Delete the pathmap
+    result = runner.invoke(
+        pathmap_app,
+        ["delete", pathmap_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        pathmap_app,
+        ["get", pathmap_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve pathmap" in result.stdout.lower()

--- a/tests/commands/test_relatedcontent.py
+++ b/tests/commands/test_relatedcontent.py
@@ -1,0 +1,93 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.relatedcontent import relatedcontent_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_relatedcontent_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for RelatedContents.
+    """
+    # 1) Create a new relatedcontent
+    term = f"term-{uuid.uuid4().hex[:8]}"
+    content = "fess"
+    result = runner.invoke(
+        relatedcontent_app,
+        ["create", "--term", term, "--content", content, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    relatedcontent_id = create_resp["response"].get("id")
+    assert relatedcontent_id, "No relatedcontent ID returned on create"
+
+    # 2) Retrieve the created relatedcontent
+    result = runner.invoke(
+        relatedcontent_app,
+        ["get", relatedcontent_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == relatedcontent_id
+    assert setting.get("term") == term
+
+    # 3) Update the relatedcontent's content
+    new_content = "n2sm"
+    result = runner.invoke(
+        relatedcontent_app,
+        ["update", relatedcontent_id, "--content", new_content, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated content
+    result = runner.invoke(
+        relatedcontent_app,
+        ["get", relatedcontent_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("content") == new_content
+
+    # 5) List relatedcontents and ensure the updated relatedcontent appears
+    result = runner.invoke(
+        relatedcontent_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert relatedcontent_id in ids
+
+    # 6) Delete the relatedcontent
+    result = runner.invoke(
+        relatedcontent_app,
+        ["delete", relatedcontent_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        relatedcontent_app,
+        ["get", relatedcontent_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve relatedcontent" in result.stdout.lower()

--- a/tests/commands/test_relatedquery.py
+++ b/tests/commands/test_relatedquery.py
@@ -1,0 +1,94 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.relatedquery import relatedquery_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_relatedquery_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for RelatedQueries.
+    """
+    # 1) Create a new relatedquery
+    term = f"term-{uuid.uuid4().hex[:8]}"
+    queries = "fess"
+    version_no = "1"
+    result = runner.invoke(
+        relatedquery_app,
+        ["create", "--term", term, "--queries", queries, "--version-no", version_no, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    relatedquery_id = create_resp["response"].get("id")
+    assert relatedquery_id, "No relatedquery ID returned on create"
+
+    # 2) Retrieve the created relatedquery
+    result = runner.invoke(
+        relatedquery_app,
+        ["get", relatedquery_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == relatedquery_id
+    assert setting.get("term") == term
+
+    # 3) Update the relatedquery's queries
+    new_queries = "n2sm"
+    result = runner.invoke(
+        relatedquery_app,
+        ["update", relatedquery_id, "--queries", new_queries, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated queries
+    result = runner.invoke(
+        relatedquery_app,
+        ["get", relatedquery_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("queries") == new_queries
+
+    # 5) List relatedqueries and ensure the updated relatedquery appears
+    result = runner.invoke(
+        relatedquery_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert relatedquery_id in ids
+
+    # 6) Delete the relatedquery
+    result = runner.invoke(
+        relatedquery_app,
+        ["delete", relatedquery_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        relatedquery_app,
+        ["get", relatedquery_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve relatedquery" in result.stdout.lower()

--- a/tests/commands/test_reqheader.py
+++ b/tests/commands/test_reqheader.py
@@ -1,0 +1,111 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.reqheader import reqheader_app
+from fessctl.commands.webconfig import webconfig_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+@pytest.fixture(scope="function")
+def temp_webconfig(runner):
+    """
+    Provides a temporary webconfig for tests that require one.
+    """
+    unique_name = f"temp-webconfig-{uuid.uuid4().hex[:8]}"
+    url = f"https://{unique_name}.com/"
+    result = runner.invoke(
+        webconfig_app,
+        ["create", "--name", unique_name, "--url", url, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Failed to create temp webconfig: {result.stdout}"
+    webconfig_id = json.loads(result.stdout)["response"]["id"]
+    yield webconfig_id
+    runner.invoke(webconfig_app, ["delete", webconfig_id])
+
+
+def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for ReqHeaders.
+    """
+    # 1) Create a new reqheader
+    name = f"header-{uuid.uuid4().hex[:8]}"
+    value = "test-value"
+    result = runner.invoke(
+        reqheader_app,
+        ["create", "--name", name, "--value", value, "--web-config-id", temp_webconfig, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    reqheader_id = create_resp["response"].get("id")
+    assert reqheader_id, "No reqheader ID returned on create"
+
+    # 2) Retrieve the created reqheader
+    result = runner.invoke(
+        reqheader_app,
+        ["get", reqheader_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == reqheader_id
+    assert setting.get("name") == name
+
+    # 3) Update the reqheader's value
+    new_value = "new-test-value"
+    result = runner.invoke(
+        reqheader_app,
+        ["update", reqheader_id, "--value", new_value, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated value
+    result = runner.invoke(
+        reqheader_app,
+        ["get", reqheader_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("value") == new_value
+
+    # 5) List reqheaders and ensure the updated reqheader appears
+    result = runner.invoke(
+        reqheader_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert reqheader_id in ids
+
+    # 6) Delete the reqheader
+    result = runner.invoke(
+        reqheader_app,
+        ["delete", reqheader_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        reqheader_app,
+        ["get", reqheader_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve reqheader" in result.stdout.lower()

--- a/tests/commands/test_scheduler.py
+++ b/tests/commands/test_scheduler.py
@@ -1,0 +1,95 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.scheduler import scheduler_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_scheduler_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for Schedulers.
+    """
+    # 1) Create a new scheduler
+    unique_name = f"schedule-{uuid.uuid4().hex[:8]}"
+    target = "all"
+    script_type = "groovy"
+    cron = "0 12 * * *"
+    result = runner.invoke(
+        scheduler_app,
+        ["create", "--name", unique_name, "--target", target, "--script-type", script_type, "--cron-expression", cron, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    scheduler_id = create_resp["response"].get("id")
+    assert scheduler_id, "No scheduler ID returned on create"
+
+    # 2) Retrieve the created scheduler
+    result = runner.invoke(
+        scheduler_app,
+        ["get", scheduler_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == scheduler_id
+    assert setting.get("name") == unique_name
+
+    # 3) Update the scheduler's cron_expression
+    new_cron = "0 13 * * *"
+    result = runner.invoke(
+        scheduler_app,
+        ["update", scheduler_id, "--cron-expression", new_cron, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated cron_expression
+    result = runner.invoke(
+        scheduler_app,
+        ["get", scheduler_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("cron_expression") == new_cron
+
+    # 5) List schedulers and ensure the updated scheduler appears
+    result = runner.invoke(
+        scheduler_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert scheduler_id in ids
+
+    # 6) Delete the scheduler
+    result = runner.invoke(
+        scheduler_app,
+        ["delete", scheduler_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        scheduler_app,
+        ["get", scheduler_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve scheduler" in result.stdout.lower()

--- a/tests/commands/test_webauth.py
+++ b/tests/commands/test_webauth.py
@@ -1,0 +1,110 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.webauth import webauth_app
+from fessctl.commands.webconfig import webconfig_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+@pytest.fixture(scope="function")
+def temp_webconfig(runner):
+    """
+    Provides a temporary webconfig for tests that require one.
+    """
+    unique_name = f"temp-webconfig-{uuid.uuid4().hex[:8]}"
+    url = f"https://{unique_name}.com/"
+    result = runner.invoke(
+        webconfig_app,
+        ["create", "--name", unique_name, "--url", url, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Failed to create temp webconfig: {result.stdout}"
+    webconfig_id = json.loads(result.stdout)["response"]["id"]
+    yield webconfig_id
+    runner.invoke(webconfig_app, ["delete", webconfig_id])
+
+
+def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for WebAuths.
+    """
+    # 1) Create a new webauth
+    username = f"user-{uuid.uuid4().hex[:8]}"
+    result = runner.invoke(
+        webauth_app,
+        ["create", "--username", username, "--web-config-id", temp_webconfig, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    webauth_id = create_resp["response"].get("id")
+    assert webauth_id, "No webauth ID returned on create"
+
+    # 2) Retrieve the created webauth
+    result = runner.invoke(
+        webauth_app,
+        ["get", webauth_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == webauth_id
+    assert setting.get("username") == username
+
+    # 3) Update the webauth's password
+    new_password = "new_password"
+    result = runner.invoke(
+        webauth_app,
+        ["update", webauth_id, "--password", new_password, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated password
+    result = runner.invoke(
+        webauth_app,
+        ["get", webauth_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("password") == new_password
+
+    # 5) List webauths and ensure the updated webauth appears
+    result = runner.invoke(
+        webauth_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert webauth_id in ids
+
+    # 6) Delete the webauth
+    result = runner.invoke(
+        webauth_app,
+        ["delete", webauth_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        webauth_app,
+        ["get", webauth_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve webauth" in result.stdout.lower()

--- a/tests/commands/test_webconfig.py
+++ b/tests/commands/test_webconfig.py
@@ -1,0 +1,93 @@
+import uuid
+import json
+import pytest
+from typer.testing import CliRunner
+
+from fessctl.commands.webconfig import webconfig_app
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """
+    Provides a CliRunner instance for invoking commands.
+    """
+    return CliRunner()
+
+
+def test_webconfig_crud_flow(runner, fess_service):
+    """
+    Tests the full Create, Read, Update, Delete (CRUD) flow for WebConfigs.
+    """
+    # 1) Create a new webconfig
+    unique_name = f"web-{uuid.uuid4().hex[:8]}"
+    url = f"https://{unique_name}.com/"
+    result = runner.invoke(
+        webconfig_app,
+        ["create", "--name", unique_name, "--url", url, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Create failed: {result.stdout}"
+    create_resp = json.loads(result.stdout)
+    assert create_resp.get("response", {}).get("status") == 0
+    webconfig_id = create_resp["response"].get("id")
+    assert webconfig_id, "No webconfig ID returned on create"
+
+    # 2) Retrieve the created webconfig
+    result = runner.invoke(
+        webconfig_app,
+        ["get", webconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get failed: {result.stdout}"
+    get_resp = json.loads(result.stdout)
+    assert get_resp.get("response", {}).get("status") == 0
+    setting = get_resp["response"].get("setting", {})
+    assert setting.get("id") == webconfig_id
+    assert setting.get("name") == unique_name
+
+    # 3) Update the webconfig's description
+    new_description = "test description"
+    result = runner.invoke(
+        webconfig_app,
+        ["update", webconfig_id, "--description", new_description, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Update failed: {result.stdout}"
+    update_resp = json.loads(result.stdout)
+    assert update_resp.get("response", {}).get("status") == 0
+
+    # 4) Retrieve again and verify updated description
+    result = runner.invoke(
+        webconfig_app,
+        ["get", webconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
+    get_after = json.loads(result.stdout)
+    setting_after = get_after["response"].get("setting", {})
+    assert setting_after.get("description") == new_description
+
+    # 5) List webconfigs and ensure the updated webconfig appears
+    result = runner.invoke(
+        webconfig_app,
+        ["list", "--output", "json"]
+    )
+    assert result.exit_code == 0, f"List failed: {result.stdout}"
+    list_resp = json.loads(result.stdout)
+    assert list_resp.get("response", {}).get("status") == 0
+    settings = list_resp["response"].get("settings", [])
+    ids = [g.get("id") for g in settings]
+    assert webconfig_id in ids
+
+    # 6) Delete the webconfig
+    result = runner.invoke(
+        webconfig_app,
+        ["delete", webconfig_id, "--output", "json"]
+    )
+    assert result.exit_code == 0, f"Delete failed: {result.stdout}"
+    del_resp = json.loads(result.stdout)
+    assert del_resp.get("response", {}).get("status") == 0
+
+    # 7) Verify that get now fails
+    result = runner.invoke(
+        webconfig_app,
+        ["get", webconfig_id]
+    )
+    assert result.exit_code != 0
+    assert "failed to retrieve webconfig" in result.stdout.lower()


### PR DESCRIPTION
This pull request addresses the following improvements:
- Error Handling Update: Updated the error exit code in elevateword.py, fileauth.py, and fileconfig.py to use a fixed exit code (1) instead of the HTTP status code. This ensures consistent CLI exit behavior.
- Bug Fix in Pathmap Command: Corrected a function call from client.create_path() to client.create_pathmap() in pathmap.py.
- Test Coverage: Added unit test files for all major command modules, including but not limited to accesstoken, badword, boostdoc, dataconfig, and others, ensuring better test coverage and maintainability.