### PR TITLE
Refactor CLI entry point to use main() function

### DIFF
--- a/src/fessctl/cli.py
+++ b/src/fessctl/cli.py
@@ -119,5 +119,9 @@ def ping(
         raise typer.Exit(code=1)
 
 
-if __name__ == "__main__":
+def main():
     app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This update refactors the CLI entry point by introducing a main() function that calls app(). The if __name__ == "__main__" block now invokes main() instead of calling app() directly. This change improves maintainability and allows the CLI to be executed programmatically from other modules without relying on the __main__ check.
