### PR TITLE
Use HTTP PUT for START/STOP actions in Fess versions above 14

### DIFF
--- a/src/fessctl/api/client.py
+++ b/src/fessctl/api/client.py
@@ -87,9 +87,14 @@ class FessAPIClient:
                     url, headers=headers, params=params, timeout=self.timeout
                 )
             elif action == Action.START or action == Action.STOP:
-                response = httpx.post(
-                    url, headers=headers, json=json_data, params=params, timeout=self.timeout
-                )
+                if self._major_version <= 14:
+                    response = httpx.post(
+                        url, headers=headers, json=json_data, params=params, timeout=self.timeout
+                    )
+                else:
+                    response = httpx.put(
+                        url, headers=headers, json=json_data, params=params, timeout=self.timeout
+                    )
             else:
                 raise ValueError("Invalid action specified")
         except httpx.RequestError as e:


### PR DESCRIPTION
This update modifies the request method for Action.START and Action.STOP in FessAPIClient.

- For Fess versions 14 or below, the client continues using httpx.post.
- For versions above 14, the client now uses httpx.put to align with API changes.

This change ensures compatibility with newer Fess API specifications while maintaining backward compatibility for older versions.