### PR TITLE
Add test matrix for multiple Fess/OpenSearch versions and dynamic Docker Compose selection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,15 @@ on:
       - main
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fess-version:
+          - fess_version: "14.19.2"
+            opensearch_version: "2.19.1"
+          - fess_version: "15.1.0"
+            opensearch_version: "3.1.0"
 
     steps:
     - uses: actions/checkout@v4
@@ -23,5 +30,8 @@ jobs:
       run: pip install uv
     - name: Install dependencies
       run: uv sync --extra dev
-    - name: Run tests
+    - name: Run tests with Fess ${{ matrix.fess-version.fess_version }} & OpenSearch ${{ matrix.fess-version.opensearch_version }}
+      env:
+        FESS_VERSION: ${{ matrix.fess-version.fess_version }}
+        OPENSEARCH_VERSION: ${{ matrix.fess-version.opensearch_version }}
       run: uv run pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.serena/
 
 # Spyder project settings
 .spyderproject

--- a/tests/compose-fess14.yaml
+++ b/tests/compose-fess14.yaml
@@ -1,11 +1,11 @@
 services:
   fessctl_fess01:
-    image: ghcr.io/codelibs/fess:14.19.2
+    image: ghcr.io/codelibs/fess:${FESS_VERSION:-14.19.2}
     container_name: fessctl_fess01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://fessctl_search01:9200"
       - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
-#      - "FESS_PLUGINS=fess-ds-csv:14.19.2"
+#      - "FESS_PLUGINS=fess-ds-csv:${FESS_VERSION:-14.19.2}"
     volumes:
 #      - fessctl_fess01_plugin:/usr/share/fess/app/WEB-INF/plugin
       - ./resources/access_token.bulk:/usr/share/fess/app/WEB-INF/classes/fess_indices/fess_config.access_token/access_token.bulk
@@ -23,7 +23,7 @@ services:
     restart: unless-stopped
     
   fessctl_search01:
-    image: ghcr.io/codelibs/fess-opensearch:2.19.1
+    image: ghcr.io/codelibs/fess-opensearch:${OPENSEARCH_VERSION:-2.19.1}
     container_name: fessctl_search01
     environment:
       - node.name=fessctl_search01

--- a/tests/compose-fess15.yaml
+++ b/tests/compose-fess15.yaml
@@ -1,0 +1,70 @@
+services:
+  fessctl_fess01:
+    image: ghcr.io/codelibs/fess:${FESS_VERSION:-15.1.0}
+    container_name: fessctl_fess01
+    environment:
+      - "SEARCH_ENGINE_HTTP_URL=http://fessctl_search01:9200"
+      - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
+#      - "FESS_PLUGINS=fess-ds-csv:${FESS_VERSION:-15.1.0}"
+    volumes:
+#      - fessctl_fess01_plugin:/usr/share/fess/app/WEB-INF/plugin
+      - ./resources/access_token.bulk:/usr/share/fess/app/WEB-INF/classes/fess_indices/fess_config.access_token/access_token.bulk
+    ports:
+      - "8080:8080"
+    networks:
+      - fessctl_search_net
+    depends_on:
+      - fessctl_search01
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    restart: unless-stopped
+    
+  fessctl_search01:
+    image: ghcr.io/codelibs/fess-opensearch:${OPENSEARCH_VERSION:-3.1.0}
+    container_name: fessctl_search01
+    environment:
+      - node.name=fessctl_search01
+      - discovery.seed_hosts=fessctl_search01
+      - cluster.initial_cluster_manager_nodes=fessctl_search01
+      - cluster.name=fess-search
+      - bootstrap.memory_lock=true
+      - node.roles=cluster_manager,data,ingest,ml
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - "FESS_DICTIONARY_PATH=/usr/share/opensearch/config/dictionary"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65535
+        hard: 65535
+#    volumes:
+#      - fessctl_search01_data:/usr/share/opensearch/data
+#      - fessctl_search01_dictionary:/usr/share/opensearch/config/dictionary
+    ports:
+      - 9200:9200
+    networks:
+      - fessctl_search_net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    restart: unless-stopped
+
+#volumes:
+#  fessctl_fess01_plugin:
+#    driver: local
+#  fessctl_search01_data:
+#    driver: local
+#  fessctl_search01_dictionary:
+#    driver: local
+
+networks:
+  fessctl_search_net:
+    driver: bridge

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,16 @@ from testcontainers.compose import DockerCompose
 def fess_service():
     project_root = Path(__file__).resolve().parent
     print(f"Project root: {project_root}")
-    compose = DockerCompose(str(project_root), "compose.yaml", pull=True)
+    
+    # Determine which compose file to use based on FESS_VERSION
+    fess_version = os.getenv("FESS_VERSION", "15.1.0")
+    if fess_version.startswith("15."):
+        compose_file = "compose-fess15.yaml"
+    else:
+        compose_file = "compose-fess14.yaml"
+    
+    print(f"Using compose file: {compose_file} for Fess version: {fess_version}")
+    compose = DockerCompose(str(project_root), compose_file, pull=True)
     compose.start()
 
     host = compose.get_service_host("fessctl_fess01", 8080)


### PR DESCRIPTION
This PR introduces support for testing against multiple versions of Fess and OpenSearch by:

- Updating the GitHub Actions workflow:
  - Renamed job from build to test.
  - Added a matrix strategy to run tests with:
    - Fess 14.19.2 + OpenSearch 2.19.1
    - Fess 15.1.0 + OpenSearch 3.1.0
  - Exposed FESS_VERSION and OPENSEARCH_VERSION as environment variables for test runs.
- Updating tests/conftest.py:
  - The Docker Compose file is now dynamically selected based on the FESS_VERSION environment variable.
  - Uses compose-fess15.yaml for Fess 15.x, otherwise defaults to compose-fess14.yaml.

This ensures broader compatibility testing and aligns test infrastructure with multiple Fess versions.