### PR TITLE
Update default Fess version from 15.4.0 to 15.6.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,8 +16,8 @@ jobs:
         fess-version:
           - fess_version: "14.19.2"
             opensearch_version: "2.19.1"
-          - fess_version: "15.4.0"
-            opensearch_version: "3.3.2"
+          - fess_version: "15.6.1"
+            opensearch_version: "3.6.0"
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The easiest way to get started is using the pre-built Docker image:
 docker run --rm \
   -e FESS_ENDPOINT=https://your-fess-server \
   -e FESS_ACCESS_TOKEN=your_access_token_here \
-  -e FESS_VERSION=15.4.0 \
+  -e FESS_VERSION=15.6.1 \
   ghcr.io/codelibs/fessctl:0.1.0 --help
 ```
 
@@ -35,13 +35,13 @@ Run actual commands:
 docker run --rm \
   -e FESS_ENDPOINT=https://your-fess-server \
   -e FESS_ACCESS_TOKEN=your_access_token_here \
-  -e FESS_VERSION=15.4.0 \
+  -e FESS_VERSION=15.6.1 \
   ghcr.io/codelibs/fessctl:0.1.0 ping
 
 docker run --rm \
   -e FESS_ENDPOINT=https://your-fess-server \
   -e FESS_ACCESS_TOKEN=your_access_token_here \
-  -e FESS_VERSION=15.4.0 \
+  -e FESS_VERSION=15.6.1 \
   ghcr.io/codelibs/fessctl:0.1.0 user list
 ```
 
@@ -61,7 +61,7 @@ Then run with your custom image:
 docker run --rm \
   -e FESS_ENDPOINT=https://your-fess-server \
   -e FESS_ACCESS_TOKEN=your_access_token_here \
-  -e FESS_VERSION=15.4.0 \
+  -e FESS_VERSION=15.6.1 \
   fessctl:latest --help
 ```
 
@@ -86,7 +86,7 @@ uv pip install -e src
 ```bash
 export FESS_ACCESS_TOKEN=your_access_token_here
 export FESS_ENDPOINT=https://your-fess-server
-export FESS_VERSION=15.4.0
+export FESS_VERSION=15.6.1
 
 fessctl --help
 fessctl ping
@@ -100,7 +100,7 @@ All three methods require the following environment variables:
 
 - `FESS_ENDPOINT`: The URL of your Fess server's API endpoint (default: `http://localhost:8080`)
 - `FESS_ACCESS_TOKEN`: Bearer token for API authentication (required)
-- `FESS_VERSION`: Target Fess version for API compatibility (default: `15.4.0`)
+- `FESS_VERSION`: Target Fess version for API compatibility (default: `15.6.1`)
 
 ## License
 

--- a/src/fessctl/config/settings.py
+++ b/src/fessctl/config/settings.py
@@ -9,4 +9,4 @@ class Settings:
     access_token: str | None = field(
         default_factory=lambda: os.getenv("FESS_ACCESS_TOKEN", None))
     fess_version: str = field(
-        default_factory=lambda: os.getenv("FESS_VERSION", "15.4.0"))
+        default_factory=lambda: os.getenv("FESS_VERSION", "15.6.1"))

--- a/tests/commands/test_accesstoken.py
+++ b/tests/commands/test_accesstoken.py
@@ -33,7 +33,7 @@ def test_accesstoken_crud_flow(runner, fess_service):
     # 2) Retrieve the created accesstoken
     result = runner.invoke(
         accesstoken_app,
-        ["get", accesstoken_id, "--output", "json"]
+        ["get", "--output", "json", "--", accesstoken_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -45,7 +45,7 @@ def test_accesstoken_crud_flow(runner, fess_service):
     # 3) Update the accesstoken's permissions
     result = runner.invoke(
         accesstoken_app,
-        ["update", accesstoken_id, "--permission", "admin", "--output", "json"]
+        ["update", "--permission", "admin", "--output", "json", "--", accesstoken_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -54,7 +54,7 @@ def test_accesstoken_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated permissions
     result = runner.invoke(
         accesstoken_app,
-        ["get", accesstoken_id, "--output", "json"]
+        ["get", "--output", "json", "--", accesstoken_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -76,7 +76,7 @@ def test_accesstoken_crud_flow(runner, fess_service):
     # 6) Delete the accesstoken
     result = runner.invoke(
         accesstoken_app,
-        ["delete", accesstoken_id, "--output", "json"]
+        ["delete", "--output", "json", "--", accesstoken_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -85,7 +85,7 @@ def test_accesstoken_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         accesstoken_app,
-        ["get", accesstoken_id]
+        ["get", "--", accesstoken_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve accesstoken" in result.stdout.lower()

--- a/tests/commands/test_badword.py
+++ b/tests/commands/test_badword.py
@@ -33,7 +33,7 @@ def test_badword_crud_flow(runner, fess_service):
     # 2) Retrieve the created badword
     result = runner.invoke(
         badword_app,
-        ["get", badword_id, "--output", "json"]
+        ["get", "--output", "json", "--", badword_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -46,7 +46,7 @@ def test_badword_crud_flow(runner, fess_service):
     new_suggest_word = f"updated-{suggest_word}"
     result = runner.invoke(
         badword_app,
-        ["update", badword_id, "--suggest-word", new_suggest_word, "--output", "json"]
+        ["update", "--suggest-word", new_suggest_word, "--output", "json", "--", badword_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -55,7 +55,7 @@ def test_badword_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated suggest_word
     result = runner.invoke(
         badword_app,
-        ["get", badword_id, "--output", "json"]
+        ["get", "--output", "json", "--", badword_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -77,7 +77,7 @@ def test_badword_crud_flow(runner, fess_service):
     # 6) Delete the badword
     result = runner.invoke(
         badword_app,
-        ["delete", badword_id, "--output", "json"]
+        ["delete", "--output", "json", "--", badword_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -86,7 +86,7 @@ def test_badword_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         badword_app,
-        ["get", badword_id]
+        ["get", "--", badword_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve badword" in result.stdout.lower()

--- a/tests/commands/test_boostdoc.py
+++ b/tests/commands/test_boostdoc.py
@@ -35,7 +35,7 @@ def test_boostdoc_crud_flow(runner, fess_service):
     # 2) Retrieve the created boostdoc
     result = runner.invoke(
         boostdoc_app,
-        ["get", boostdoc_id, "--output", "json"]
+        ["get", "--output", "json", "--", boostdoc_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -48,7 +48,7 @@ def test_boostdoc_crud_flow(runner, fess_service):
     new_boost_expr = "20.0"
     result = runner.invoke(
         boostdoc_app,
-        ["update", boostdoc_id, "--boost-expr", new_boost_expr, "--output", "json"]
+        ["update", "--boost-expr", new_boost_expr, "--output", "json", "--", boostdoc_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -57,7 +57,7 @@ def test_boostdoc_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated boost_expr
     result = runner.invoke(
         boostdoc_app,
-        ["get", boostdoc_id, "--output", "json"]
+        ["get", "--output", "json", "--", boostdoc_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -79,7 +79,7 @@ def test_boostdoc_crud_flow(runner, fess_service):
     # 6) Delete the boostdoc
     result = runner.invoke(
         boostdoc_app,
-        ["delete", boostdoc_id, "--output", "json"]
+        ["delete", "--output", "json", "--", boostdoc_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -88,7 +88,7 @@ def test_boostdoc_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         boostdoc_app,
-        ["get", boostdoc_id]
+        ["get", "--", boostdoc_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve boostdoc" in result.stdout.lower()

--- a/tests/commands/test_dataconfig.py
+++ b/tests/commands/test_dataconfig.py
@@ -34,7 +34,7 @@ def test_dataconfig_crud_flow(runner, fess_service):
     # 2) Retrieve the created dataconfig
     result = runner.invoke(
         dataconfig_app,
-        ["get", dataconfig_id, "--output", "json"]
+        ["get", "--output", "json", "--", dataconfig_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -47,7 +47,7 @@ def test_dataconfig_crud_flow(runner, fess_service):
     new_description = "test description"
     result = runner.invoke(
         dataconfig_app,
-        ["update", dataconfig_id, "--description", new_description, "--output", "json"]
+        ["update", "--description", new_description, "--output", "json", "--", dataconfig_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -56,7 +56,7 @@ def test_dataconfig_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated description
     result = runner.invoke(
         dataconfig_app,
-        ["get", dataconfig_id, "--output", "json"]
+        ["get", "--output", "json", "--", dataconfig_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -78,7 +78,7 @@ def test_dataconfig_crud_flow(runner, fess_service):
     # 6) Delete the dataconfig
     result = runner.invoke(
         dataconfig_app,
-        ["delete", dataconfig_id, "--output", "json"]
+        ["delete", "--output", "json", "--", dataconfig_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -87,7 +87,7 @@ def test_dataconfig_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         dataconfig_app,
-        ["get", dataconfig_id]
+        ["get", "--", dataconfig_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve dataconfig" in result.stdout.lower()

--- a/tests/commands/test_duplicatehost.py
+++ b/tests/commands/test_duplicatehost.py
@@ -35,7 +35,7 @@ def test_duplicatehost_crud_flow(runner, fess_service):
     # 2) Retrieve the created duplicatehost
     result = runner.invoke(
         duplicatehost_app,
-        ["get", duplicatehost_id, "--output", "json"]
+        ["get", "--output", "json", "--", duplicatehost_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -48,7 +48,7 @@ def test_duplicatehost_crud_flow(runner, fess_service):
     new_sort_order = "10"
     result = runner.invoke(
         duplicatehost_app,
-        ["update", duplicatehost_id, "--sort-order", new_sort_order, "--output", "json"]
+        ["update", "--sort-order", new_sort_order, "--output", "json", "--", duplicatehost_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -57,7 +57,7 @@ def test_duplicatehost_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated sort_order
     result = runner.invoke(
         duplicatehost_app,
-        ["get", duplicatehost_id, "--output", "json"]
+        ["get", "--output", "json", "--", duplicatehost_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -79,7 +79,7 @@ def test_duplicatehost_crud_flow(runner, fess_service):
     # 6) Delete the duplicatehost
     result = runner.invoke(
         duplicatehost_app,
-        ["delete", duplicatehost_id, "--output", "json"]
+        ["delete", "--output", "json", "--", duplicatehost_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -88,7 +88,7 @@ def test_duplicatehost_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         duplicatehost_app,
-        ["get", duplicatehost_id]
+        ["get", "--", duplicatehost_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve duplicatehost" in result.stdout.lower()

--- a/tests/commands/test_elevateword.py
+++ b/tests/commands/test_elevateword.py
@@ -35,7 +35,7 @@ def test_elevateword_crud_flow(runner, fess_service):
     # 2) Retrieve the created elevateword
     result = runner.invoke(
         elevateword_app,
-        ["get", elevateword_id, "--output", "json"]
+        ["get", "--output", "json", "--", elevateword_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -48,7 +48,7 @@ def test_elevateword_crud_flow(runner, fess_service):
     new_boost = "20.0"
     result = runner.invoke(
         elevateword_app,
-        ["update", elevateword_id, "--boost", new_boost, "--output", "json"]
+        ["update", "--boost", new_boost, "--output", "json", "--", elevateword_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -57,7 +57,7 @@ def test_elevateword_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated boost
     result = runner.invoke(
         elevateword_app,
-        ["get", elevateword_id, "--output", "json"]
+        ["get", "--output", "json", "--", elevateword_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -79,7 +79,7 @@ def test_elevateword_crud_flow(runner, fess_service):
     # 6) Delete the elevateword
     result = runner.invoke(
         elevateword_app,
-        ["delete", elevateword_id, "--output", "json"]
+        ["delete", "--output", "json", "--", elevateword_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -88,7 +88,7 @@ def test_elevateword_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         elevateword_app,
-        ["get", elevateword_id]
+        ["get", "--", elevateword_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve elevateword" in result.stdout.lower()

--- a/tests/commands/test_fileauth.py
+++ b/tests/commands/test_fileauth.py
@@ -29,7 +29,7 @@ def temp_fileconfig(runner):
     assert result.exit_code == 0, f"Failed to create temp fileconfig: {result.stdout}"
     fileconfig_id = json.loads(result.stdout)["response"]["id"]
     yield fileconfig_id
-    runner.invoke(fileconfig_app, ["delete", fileconfig_id])
+    runner.invoke(fileconfig_app, ["delete", "--", fileconfig_id])
 
 
 def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
@@ -51,7 +51,7 @@ def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
     # 2) Retrieve the created fileauth
     result = runner.invoke(
         fileauth_app,
-        ["get", fileauth_id, "--output", "json"]
+        ["get", "--output", "json", "--", fileauth_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -64,7 +64,7 @@ def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
     new_password = "new_password"
     result = runner.invoke(
         fileauth_app,
-        ["update", fileauth_id, "--password", new_password, "--output", "json"]
+        ["update", "--password", new_password, "--output", "json", "--", fileauth_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -73,7 +73,7 @@ def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
     # 4) Retrieve again and verify updated password
     result = runner.invoke(
         fileauth_app,
-        ["get", fileauth_id, "--output", "json"]
+        ["get", "--output", "json", "--", fileauth_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -95,7 +95,7 @@ def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
     # 6) Delete the fileauth
     result = runner.invoke(
         fileauth_app,
-        ["delete", fileauth_id, "--output", "json"]
+        ["delete", "--output", "json", "--", fileauth_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -104,7 +104,7 @@ def test_fileauth_crud_flow(runner, fess_service, temp_fileconfig):
     # 7) Verify that get now fails
     result = runner.invoke(
         fileauth_app,
-        ["get", fileauth_id]
+        ["get", "--", fileauth_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve fileauth" in result.stdout.lower()

--- a/tests/commands/test_fileconfig.py
+++ b/tests/commands/test_fileconfig.py
@@ -34,7 +34,7 @@ def test_fileconfig_crud_flow(runner, fess_service):
     # 2) Retrieve the created fileconfig
     result = runner.invoke(
         fileconfig_app,
-        ["get", fileconfig_id, "--output", "json"]
+        ["get", "--output", "json", "--", fileconfig_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -47,7 +47,7 @@ def test_fileconfig_crud_flow(runner, fess_service):
     new_description = "test description"
     result = runner.invoke(
         fileconfig_app,
-        ["update", fileconfig_id, "--description", new_description, "--output", "json"]
+        ["update", "--description", new_description, "--output", "json", "--", fileconfig_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -56,7 +56,7 @@ def test_fileconfig_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated description
     result = runner.invoke(
         fileconfig_app,
-        ["get", fileconfig_id, "--output", "json"]
+        ["get", "--output", "json", "--", fileconfig_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -78,7 +78,7 @@ def test_fileconfig_crud_flow(runner, fess_service):
     # 6) Delete the fileconfig
     result = runner.invoke(
         fileconfig_app,
-        ["delete", fileconfig_id, "--output", "json"]
+        ["delete", "--output", "json", "--", fileconfig_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -87,7 +87,7 @@ def test_fileconfig_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         fileconfig_app,
-        ["get", fileconfig_id]
+        ["get", "--", fileconfig_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve fileconfig" in result.stdout.lower()

--- a/tests/commands/test_group.py
+++ b/tests/commands/test_group.py
@@ -27,7 +27,7 @@ def test_group_crud_flow(runner, fess_service):
     # 2) Retrieve the created group
     result = runner.invoke(
         group_app,
-        ["get", group_id, "--output", "json"]
+        ["get", "--output", "json", "--", group_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -41,7 +41,7 @@ def test_group_crud_flow(runner, fess_service):
     # 3) Update the group's attributes
     result = runner.invoke(
         group_app,
-        ["update", group_id, "--attribute", "key1=val1", "--output", "json"]
+        ["update", "--attribute", "key1=val1", "--output", "json", "--", group_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -50,7 +50,7 @@ def test_group_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated attributes
     result = runner.invoke(
         group_app,
-        ["get", group_id, "--output", "json"]
+        ["get", "--output", "json", "--", group_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -78,7 +78,7 @@ def test_group_crud_flow(runner, fess_service):
     # 6) Delete the group
     result = runner.invoke(
         group_app,
-        ["delete", group_id, "--output", "json"]
+        ["delete", "--output", "json", "--", group_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -87,7 +87,7 @@ def test_group_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         group_app,
-        ["get", group_id]
+        ["get", "--", group_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve group" in result.stdout.lower()
@@ -116,4 +116,4 @@ def test_getbyname_group(runner, fess_service):
     assert setting["id"] == group_id
     assert setting["name"] == unique_name
 
-    runner.invoke(group_app, ["delete", group_id, "--output", "json"])
+    runner.invoke(group_app, ["delete", "--output", "json", "--", group_id])

--- a/tests/commands/test_keymatch.py
+++ b/tests/commands/test_keymatch.py
@@ -37,7 +37,7 @@ def test_keymatch_crud_flow(runner, fess_service):
     # 2) Retrieve the created keymatch
     result = runner.invoke(
         keymatch_app,
-        ["get", keymatch_id, "--output", "json"]
+        ["get", "--output", "json", "--", keymatch_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -50,7 +50,7 @@ def test_keymatch_crud_flow(runner, fess_service):
     new_boost = "200.0"
     result = runner.invoke(
         keymatch_app,
-        ["update", keymatch_id, "--boost", new_boost, "--output", "json"]
+        ["update", "--boost", new_boost, "--output", "json", "--", keymatch_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -59,7 +59,7 @@ def test_keymatch_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated boost
     result = runner.invoke(
         keymatch_app,
-        ["get", keymatch_id, "--output", "json"]
+        ["get", "--output", "json", "--", keymatch_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -81,7 +81,7 @@ def test_keymatch_crud_flow(runner, fess_service):
     # 6) Delete the keymatch
     result = runner.invoke(
         keymatch_app,
-        ["delete", keymatch_id, "--output", "json"]
+        ["delete", "--output", "json", "--", keymatch_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -90,7 +90,7 @@ def test_keymatch_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         keymatch_app,
-        ["get", keymatch_id]
+        ["get", "--", keymatch_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve keymatch" in result.stdout.lower()

--- a/tests/commands/test_labeltype.py
+++ b/tests/commands/test_labeltype.py
@@ -35,7 +35,7 @@ def test_labeltype_crud_flow(runner, fess_service):
     # 2) Retrieve the created labeltype
     result = runner.invoke(
         labeltype_app,
-        ["get", labeltype_id, "--output", "json"]
+        ["get", "--output", "json", "--", labeltype_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -48,7 +48,7 @@ def test_labeltype_crud_flow(runner, fess_service):
     new_name = f"new-{name}"
     result = runner.invoke(
         labeltype_app,
-        ["update", labeltype_id, "--name", new_name, "--output", "json"]
+        ["update", "--name", new_name, "--output", "json", "--", labeltype_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -57,7 +57,7 @@ def test_labeltype_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated name
     result = runner.invoke(
         labeltype_app,
-        ["get", labeltype_id, "--output", "json"]
+        ["get", "--output", "json", "--", labeltype_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -79,7 +79,7 @@ def test_labeltype_crud_flow(runner, fess_service):
     # 6) Delete the labeltype
     result = runner.invoke(
         labeltype_app,
-        ["delete", labeltype_id, "--output", "json"]
+        ["delete", "--output", "json", "--", labeltype_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -88,7 +88,7 @@ def test_labeltype_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         labeltype_app,
-        ["get", labeltype_id]
+        ["get", "--", labeltype_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve labeltype" in result.stdout.lower()

--- a/tests/commands/test_pathmap.py
+++ b/tests/commands/test_pathmap.py
@@ -35,7 +35,7 @@ def test_pathmap_crud_flow(runner, fess_service):
     # 2) Retrieve the created pathmap
     result = runner.invoke(
         pathmap_app,
-        ["get", pathmap_id, "--output", "json"]
+        ["get", "--output", "json", "--", pathmap_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -48,7 +48,7 @@ def test_pathmap_crud_flow(runner, fess_service):
     new_replacement = "https://www.n2sm.net/"
     result = runner.invoke(
         pathmap_app,
-        ["update", pathmap_id, "--replacement", new_replacement, "--output", "json"]
+        ["update", "--replacement", new_replacement, "--output", "json", "--", pathmap_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -57,7 +57,7 @@ def test_pathmap_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated replacement
     result = runner.invoke(
         pathmap_app,
-        ["get", pathmap_id, "--output", "json"]
+        ["get", "--output", "json", "--", pathmap_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -79,7 +79,7 @@ def test_pathmap_crud_flow(runner, fess_service):
     # 6) Delete the pathmap
     result = runner.invoke(
         pathmap_app,
-        ["delete", pathmap_id, "--output", "json"]
+        ["delete", "--output", "json", "--", pathmap_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -88,7 +88,7 @@ def test_pathmap_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         pathmap_app,
-        ["get", pathmap_id]
+        ["get", "--", pathmap_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve pathmap" in result.stdout.lower()

--- a/tests/commands/test_relatedcontent.py
+++ b/tests/commands/test_relatedcontent.py
@@ -34,7 +34,7 @@ def test_relatedcontent_crud_flow(runner, fess_service):
     # 2) Retrieve the created relatedcontent
     result = runner.invoke(
         relatedcontent_app,
-        ["get", relatedcontent_id, "--output", "json"]
+        ["get", "--output", "json", "--", relatedcontent_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -47,7 +47,7 @@ def test_relatedcontent_crud_flow(runner, fess_service):
     new_content = "n2sm"
     result = runner.invoke(
         relatedcontent_app,
-        ["update", relatedcontent_id, "--content", new_content, "--output", "json"]
+        ["update", "--content", new_content, "--output", "json", "--", relatedcontent_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -56,7 +56,7 @@ def test_relatedcontent_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated content
     result = runner.invoke(
         relatedcontent_app,
-        ["get", relatedcontent_id, "--output", "json"]
+        ["get", "--output", "json", "--", relatedcontent_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -78,7 +78,7 @@ def test_relatedcontent_crud_flow(runner, fess_service):
     # 6) Delete the relatedcontent
     result = runner.invoke(
         relatedcontent_app,
-        ["delete", relatedcontent_id, "--output", "json"]
+        ["delete", "--output", "json", "--", relatedcontent_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -87,7 +87,7 @@ def test_relatedcontent_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         relatedcontent_app,
-        ["get", relatedcontent_id]
+        ["get", "--", relatedcontent_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve relatedcontent" in result.stdout.lower()

--- a/tests/commands/test_relatedquery.py
+++ b/tests/commands/test_relatedquery.py
@@ -35,7 +35,7 @@ def test_relatedquery_crud_flow(runner, fess_service):
     # 2) Retrieve the created relatedquery
     result = runner.invoke(
         relatedquery_app,
-        ["get", relatedquery_id, "--output", "json"]
+        ["get", "--output", "json", "--", relatedquery_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -48,7 +48,7 @@ def test_relatedquery_crud_flow(runner, fess_service):
     new_queries = "n2sm"
     result = runner.invoke(
         relatedquery_app,
-        ["update", relatedquery_id, "--queries", new_queries, "--output", "json"]
+        ["update", "--queries", new_queries, "--output", "json", "--", relatedquery_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -57,7 +57,7 @@ def test_relatedquery_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated queries
     result = runner.invoke(
         relatedquery_app,
-        ["get", relatedquery_id, "--output", "json"]
+        ["get", "--output", "json", "--", relatedquery_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -79,7 +79,7 @@ def test_relatedquery_crud_flow(runner, fess_service):
     # 6) Delete the relatedquery
     result = runner.invoke(
         relatedquery_app,
-        ["delete", relatedquery_id, "--output", "json"]
+        ["delete", "--output", "json", "--", relatedquery_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -88,7 +88,7 @@ def test_relatedquery_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         relatedquery_app,
-        ["get", relatedquery_id]
+        ["get", "--", relatedquery_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve relatedquery" in result.stdout.lower()

--- a/tests/commands/test_reqheader.py
+++ b/tests/commands/test_reqheader.py
@@ -29,7 +29,7 @@ def temp_webconfig(runner):
     assert result.exit_code == 0, f"Failed to create temp webconfig: {result.stdout}"
     webconfig_id = json.loads(result.stdout)["response"]["id"]
     yield webconfig_id
-    runner.invoke(webconfig_app, ["delete", webconfig_id])
+    runner.invoke(webconfig_app, ["delete", "--", webconfig_id])
 
 
 def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
@@ -52,7 +52,7 @@ def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
     # 2) Retrieve the created reqheader
     result = runner.invoke(
         reqheader_app,
-        ["get", reqheader_id, "--output", "json"]
+        ["get", "--output", "json", "--", reqheader_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -65,7 +65,7 @@ def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
     new_value = "new-test-value"
     result = runner.invoke(
         reqheader_app,
-        ["update", reqheader_id, "--value", new_value, "--output", "json"]
+        ["update", "--value", new_value, "--output", "json", "--", reqheader_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -74,7 +74,7 @@ def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
     # 4) Retrieve again and verify updated value
     result = runner.invoke(
         reqheader_app,
-        ["get", reqheader_id, "--output", "json"]
+        ["get", "--output", "json", "--", reqheader_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -96,7 +96,7 @@ def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
     # 6) Delete the reqheader
     result = runner.invoke(
         reqheader_app,
-        ["delete", reqheader_id, "--output", "json"]
+        ["delete", "--output", "json", "--", reqheader_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -105,7 +105,7 @@ def test_reqheader_crud_flow(runner, fess_service, temp_webconfig):
     # 7) Verify that get now fails
     result = runner.invoke(
         reqheader_app,
-        ["get", reqheader_id]
+        ["get", "--", reqheader_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve reqheader" in result.stdout.lower()

--- a/tests/commands/test_role.py
+++ b/tests/commands/test_role.py
@@ -27,7 +27,7 @@ def test_role_crud_flow(runner, fess_service):
     # 2) Retrieve the created role
     result = runner.invoke(
         role_app,
-        ["get", role_id, "--output", "json"]
+        ["get", "--output", "json", "--", role_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -41,7 +41,7 @@ def test_role_crud_flow(runner, fess_service):
     # 3) Update the role's attributes
     result = runner.invoke(
         role_app,
-        ["update", role_id, "--attribute", "key1=val1", "--output", "json"]
+        ["update", "--attribute", "key1=val1", "--output", "json", "--", role_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -50,7 +50,7 @@ def test_role_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated attributes
     result = runner.invoke(
         role_app,
-        ["get", role_id, "--output", "json"]
+        ["get", "--output", "json", "--", role_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -78,7 +78,7 @@ def test_role_crud_flow(runner, fess_service):
     # 6) Delete the role
     result = runner.invoke(
         role_app,
-        ["delete", role_id, "--output", "json"]
+        ["delete", "--output", "json", "--", role_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -87,7 +87,7 @@ def test_role_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         role_app,
-        ["get", role_id]
+        ["get", "--", role_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve role" in result.stdout.lower()
@@ -117,4 +117,4 @@ def test_getbyname_role(runner, fess_service):
     assert setting["name"] == unique_name
 
     # Cleanup
-    runner.invoke(role_app, ["delete", role_id, "--output", "json"])
+    runner.invoke(role_app, ["delete", "--output", "json", "--", role_id])

--- a/tests/commands/test_scheduler.py
+++ b/tests/commands/test_scheduler.py
@@ -36,7 +36,7 @@ def test_scheduler_crud_flow(runner, fess_service):
     # 2) Retrieve the created scheduler
     result = runner.invoke(
         scheduler_app,
-        ["get", scheduler_id, "--output", "json"]
+        ["get", "--output", "json", "--", scheduler_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -49,7 +49,7 @@ def test_scheduler_crud_flow(runner, fess_service):
     new_cron = "0 13 * * *"
     result = runner.invoke(
         scheduler_app,
-        ["update", scheduler_id, "--cron-expression", new_cron, "--output", "json"]
+        ["update", "--cron-expression", new_cron, "--output", "json", "--", scheduler_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -58,7 +58,7 @@ def test_scheduler_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated cron_expression
     result = runner.invoke(
         scheduler_app,
-        ["get", scheduler_id, "--output", "json"]
+        ["get", "--output", "json", "--", scheduler_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -80,7 +80,7 @@ def test_scheduler_crud_flow(runner, fess_service):
     # 6) Delete the scheduler
     result = runner.invoke(
         scheduler_app,
-        ["delete", scheduler_id, "--output", "json"]
+        ["delete", "--output", "json", "--", scheduler_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -89,7 +89,7 @@ def test_scheduler_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         scheduler_app,
-        ["get", scheduler_id]
+        ["get", "--", scheduler_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve scheduler" in result.stdout.lower()
@@ -120,7 +120,7 @@ def test_scheduler_start_stop_json_output(runner, fess_service):
         # 2) Start the scheduler - verify returns valid JSON with response structure
         result = runner.invoke(
             scheduler_app,
-            ["start", scheduler_id, "--output", "json"]
+            ["start", "--output", "json", "--", scheduler_id]
         )
         # Command should return JSON regardless of success/failure
         start_resp = json.loads(result.stdout)
@@ -130,7 +130,7 @@ def test_scheduler_start_stop_json_output(runner, fess_service):
         # 3) Stop the scheduler - verify returns valid JSON with response structure
         result = runner.invoke(
             scheduler_app,
-            ["stop", scheduler_id, "--output", "json"]
+            ["stop", "--output", "json", "--", scheduler_id]
         )
         stop_resp = json.loads(result.stdout)
         assert "response" in stop_resp
@@ -140,7 +140,7 @@ def test_scheduler_start_stop_json_output(runner, fess_service):
         # 4) Clean up - delete the scheduler
         runner.invoke(
             scheduler_app,
-            ["delete", scheduler_id, "--output", "json"]
+            ["delete", "--output", "json", "--", scheduler_id]
         )
 
 
@@ -162,7 +162,7 @@ def test_scheduler_start_text_output(runner, fess_service):
         # Start with text output - should produce some output
         result = runner.invoke(
             scheduler_app,
-            ["start", scheduler_id, "--output", "text"]
+            ["start", "--output", "text", "--", scheduler_id]
         )
         # Verify there is output (either success or failure message)
         assert len(result.stdout) > 0
@@ -171,13 +171,13 @@ def test_scheduler_start_text_output(runner, fess_service):
         # Stop with text output - should produce some output
         result = runner.invoke(
             scheduler_app,
-            ["stop", scheduler_id, "--output", "text"]
+            ["stop", "--output", "text", "--", scheduler_id]
         )
         assert len(result.stdout) > 0
         assert "scheduler" in result.stdout.lower()
 
     finally:
-        runner.invoke(scheduler_app, ["delete", scheduler_id])
+        runner.invoke(scheduler_app, ["delete", "--", scheduler_id])
 
 
 def test_scheduler_start_yaml_output(runner, fess_service):
@@ -197,13 +197,13 @@ def test_scheduler_start_yaml_output(runner, fess_service):
         # Start with YAML output - verify YAML structure
         result = runner.invoke(
             scheduler_app,
-            ["start", scheduler_id, "--output", "yaml"]
+            ["start", "--output", "yaml", "--", scheduler_id]
         )
         # YAML output should contain response key
         assert "response:" in result.stdout
 
     finally:
-        runner.invoke(scheduler_app, ["delete", scheduler_id])
+        runner.invoke(scheduler_app, ["delete", "--", scheduler_id])
 
 
 def test_scheduler_start_nonexistent(runner, fess_service):

--- a/tests/commands/test_user.py
+++ b/tests/commands/test_user.py
@@ -33,7 +33,7 @@ def test_user_crud_flow(runner, fess_service):
     # 2) Retrieve the created user
     result = runner.invoke(
         user_app,
-        ["get", user_id, "--output", "json"]
+        ["get", "--output", "json", "--", user_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -69,7 +69,7 @@ def test_user_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated fields
     result = runner.invoke(
         user_app,
-        ["get", user_id, "--output", "json"]
+        ["get", "--output", "json", "--", user_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -106,7 +106,7 @@ def test_user_crud_flow(runner, fess_service):
     # 6) Delete the user
     result = runner.invoke(
         user_app,
-        ["delete", user_id, "--output", "json"]
+        ["delete", "--output", "json", "--", user_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -115,7 +115,7 @@ def test_user_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         user_app,
-        ["get", user_id]
+        ["get", "--", user_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve user" in result.stdout.lower()
@@ -146,4 +146,4 @@ def test_getbyname_user(runner, fess_service):
     assert setting["name"] == unique_name
 
     # Cleanup
-    runner.invoke(user_app, ["delete", user_id, "--output", "json"])
+    runner.invoke(user_app, ["delete", "--output", "json", "--", user_id])

--- a/tests/commands/test_webauth.py
+++ b/tests/commands/test_webauth.py
@@ -29,7 +29,7 @@ def temp_webconfig(runner):
     assert result.exit_code == 0, f"Failed to create temp webconfig: {result.stdout}"
     webconfig_id = json.loads(result.stdout)["response"]["id"]
     yield webconfig_id
-    runner.invoke(webconfig_app, ["delete", webconfig_id])
+    runner.invoke(webconfig_app, ["delete", "--", webconfig_id])
 
 
 def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
@@ -51,7 +51,7 @@ def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
     # 2) Retrieve the created webauth
     result = runner.invoke(
         webauth_app,
-        ["get", webauth_id, "--output", "json"]
+        ["get", "--output", "json", "--", webauth_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -64,7 +64,7 @@ def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
     new_password = "new_password"
     result = runner.invoke(
         webauth_app,
-        ["update", webauth_id, "--password", new_password, "--output", "json"]
+        ["update", "--password", new_password, "--output", "json", "--", webauth_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -73,7 +73,7 @@ def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
     # 4) Retrieve again and verify updated password
     result = runner.invoke(
         webauth_app,
-        ["get", webauth_id, "--output", "json"]
+        ["get", "--output", "json", "--", webauth_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -95,7 +95,7 @@ def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
     # 6) Delete the webauth
     result = runner.invoke(
         webauth_app,
-        ["delete", webauth_id, "--output", "json"]
+        ["delete", "--output", "json", "--", webauth_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -104,7 +104,7 @@ def test_webauth_crud_flow(runner, fess_service, temp_webconfig):
     # 7) Verify that get now fails
     result = runner.invoke(
         webauth_app,
-        ["get", webauth_id]
+        ["get", "--", webauth_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve webauth" in result.stdout.lower()

--- a/tests/commands/test_webconfig.py
+++ b/tests/commands/test_webconfig.py
@@ -34,7 +34,7 @@ def test_webconfig_crud_flow(runner, fess_service):
     # 2) Retrieve the created webconfig
     result = runner.invoke(
         webconfig_app,
-        ["get", webconfig_id, "--output", "json"]
+        ["get", "--output", "json", "--", webconfig_id]
     )
     assert result.exit_code == 0, f"Get failed: {result.stdout}"
     get_resp = json.loads(result.stdout)
@@ -47,7 +47,7 @@ def test_webconfig_crud_flow(runner, fess_service):
     new_description = "test description"
     result = runner.invoke(
         webconfig_app,
-        ["update", webconfig_id, "--description", new_description, "--output", "json"]
+        ["update", "--description", new_description, "--output", "json", "--", webconfig_id]
     )
     assert result.exit_code == 0, f"Update failed: {result.stdout}"
     update_resp = json.loads(result.stdout)
@@ -56,7 +56,7 @@ def test_webconfig_crud_flow(runner, fess_service):
     # 4) Retrieve again and verify updated description
     result = runner.invoke(
         webconfig_app,
-        ["get", webconfig_id, "--output", "json"]
+        ["get", "--output", "json", "--", webconfig_id]
     )
     assert result.exit_code == 0, f"Get after update failed: {result.stdout}"
     get_after = json.loads(result.stdout)
@@ -78,7 +78,7 @@ def test_webconfig_crud_flow(runner, fess_service):
     # 6) Delete the webconfig
     result = runner.invoke(
         webconfig_app,
-        ["delete", webconfig_id, "--output", "json"]
+        ["delete", "--output", "json", "--", webconfig_id]
     )
     assert result.exit_code == 0, f"Delete failed: {result.stdout}"
     del_resp = json.loads(result.stdout)
@@ -87,7 +87,7 @@ def test_webconfig_crud_flow(runner, fess_service):
     # 7) Verify that get now fails
     result = runner.invoke(
         webconfig_app,
-        ["get", webconfig_id]
+        ["get", "--", webconfig_id]
     )
     assert result.exit_code != 0
     assert "failed to retrieve webconfig" in result.stdout.lower()

--- a/tests/compose-fess15.yaml
+++ b/tests/compose-fess15.yaml
@@ -1,11 +1,11 @@
 services:
   fessctl_fess01:
-    image: ghcr.io/codelibs/fess:${FESS_VERSION:-15.4.0}
+    image: ghcr.io/codelibs/fess:${FESS_VERSION:-15.6.1}
     container_name: fessctl_fess01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://fessctl_search01:9200"
       - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
-#      - "FESS_PLUGINS=fess-ds-csv:${FESS_VERSION:-15.4.0}"
+#      - "FESS_PLUGINS=fess-ds-csv:${FESS_VERSION:-15.6.1}"
     volumes:
 #      - fessctl_fess01_plugin:/usr/share/fess/app/WEB-INF/plugin
       - ./resources/access_token.bulk:/usr/share/fess/app/WEB-INF/classes/fess_indices/fess_config.access_token/access_token.bulk
@@ -23,7 +23,7 @@ services:
     restart: unless-stopped
     
   fessctl_search01:
-    image: ghcr.io/codelibs/fess-opensearch:${OPENSEARCH_VERSION:-3.3.2}
+    image: ghcr.io/codelibs/fess-opensearch:${OPENSEARCH_VERSION:-3.6.0}
     container_name: fessctl_search01
     environment:
       - node.name=fessctl_search01

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def fess_service():
     print(f"Project root: {project_root}")
     
     # Determine which compose file to use based on FESS_VERSION
-    fess_version = os.getenv("FESS_VERSION", "15.3.2")
+    fess_version = os.getenv("FESS_VERSION", "15.6.1")
     if fess_version.startswith("15."):
         compose_file = "compose-fess15.yaml"
     else:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,7 +17,7 @@ def mock_settings():
     settings = Mock(spec=Settings)
     settings.fess_endpoint = "http://localhost:8080"
     settings.access_token = "test-token"
-    settings.fess_version = "15.4.0"
+    settings.fess_version = "15.6.1"
     return settings
 
 
@@ -53,7 +53,7 @@ class TestFessAPIClientInit:
         assert client.base_url == "http://localhost:8080"
         assert client.timeout == 5.0
         assert client._major_version == 15
-        assert client._minor_version == 4
+        assert client._minor_version == 6
 
     def test_init_with_custom_timeout(self, mock_settings):
         """Test client initialization with custom timeout."""

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -21,7 +21,7 @@ class TestSettings:
 
         assert settings.fess_endpoint == "http://localhost:8080"
         assert settings.access_token is None
-        assert settings.fess_version == "15.4.0"
+        assert settings.fess_version == "15.6.1"
 
     def test_endpoint_from_environment(self, monkeypatch):
         """Test that FESS_ENDPOINT environment variable is used."""


### PR DESCRIPTION
## Summary
- Bump default `FESS_VERSION` from `15.4.0` to `15.6.1` (latest Fess release)
- Bump default `OPENSEARCH_VERSION` from `3.3.2` to `3.6.0` to match `fess-parent` 15.6.0
- Update CI matrix, README examples, and unit-test expectations accordingly

## Test plan
- [x] `uv run pytest tests/unit/` — 104 passed
- [ ] CI matrix runs Fess `15.6.1` / OpenSearch `3.6.0` integration tests