### PR TITLE
Distribute fessctl via PyPI (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: publish
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+# Least-privilege: read-only by default; each job adds only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Assert tag trigger
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          case "${GITHUB_REF}" in
+            refs/tags/v*) ;;
+            *) echo "publish.yml workflow_dispatch requires a v* tag ref"; exit 1 ;;
+          esac
+
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Validate tag matches pyproject version
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PROJECT_VERSION=$(uv run --no-project --python 3.13 python -c \
+            "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$PROJECT_VERSION" ]; then
+            echo "::error::Tag v$TAG does not match pyproject.toml version $PROJECT_VERSION"
+            exit 1
+          fi
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-24.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fessctl
+    permissions:
+      id-token: write      # Required for OIDC trusted publishing
+      attestations: write  # Required for Sigstore attestations (pypa/gh-action-pypi-publish v1.10+)
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          generate-attestations: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fess is an open-source enterprise search server based on OpenSearch.
 
 ## Installation and Usage
 
-There are three ways to use fessctl:
+There are four ways to use fessctl:
 
 ### Method 1: Using Pre-built Docker Image
 
@@ -94,9 +94,34 @@ fessctl user list
 fessctl webconfig create --name TestConfig --url https://test.config.com/
 ```
 
+### Method 4: Install from PyPI
+
+`fessctl` is published to [PyPI](https://pypi.org/project/fessctl/). Install it with `pip`,
+or use [`pipx`](https://pipx.pypa.io/) / [`uv tool`](https://docs.astral.sh/uv/guides/tools/)
+for an isolated, globally available CLI:
+
+```bash
+pip install fessctl
+# or, for an isolated install:
+pipx install fessctl
+# or:
+uv tool install fessctl
+```
+
+#### Usage
+```bash
+export FESS_ACCESS_TOKEN=your_access_token_here
+export FESS_ENDPOINT=https://your-fess-server
+export FESS_VERSION=15.6.1
+
+fessctl --help
+fessctl ping
+fessctl user list
+```
+
 ## Environment Variables
 
-All three methods require the following environment variables:
+All four methods require the following environment variables:
 
 - `FESS_ENDPOINT`: The URL of your Fess server's API endpoint (default: `http://localhost:8080`)
 - `FESS_ACCESS_TOKEN`: Bearer token for API authentication (required)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [project]
 name = "fessctl"
-version = "0.2.0.dev"
+version = "0.2.0"
 description = "CLI tool to manage Fess using the admin API"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "CodeLibs, Inc.", email = "info@codelibs.co" }]
 requires-python = ">=3.13"
 dependencies = [
@@ -28,7 +31,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -102,7 +102,7 @@ wheels = [
 
 [[package]]
 name = "fessctl"
-version = "0.2.0.dev0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Distributes `fessctl` via [PyPI](https://pypi.org/project/fessctl/) instead of Homebrew. On every `v*` tag push, a release workflow builds the sdist + wheel with `uv build` and publishes them to PyPI using **Trusted Publishing (OIDC)** — no long-lived API token.

`fessctl` is a pure-Python CLI, so PyPI (`pip` / `pipx` / `uv tool`) is the natural distribution channel. The OIDC Trusted Publishing flow mirrors how `recotem` already publishes under the CodeLibs PyPI account.

## What's in this branch

- **Release workflow** (`.github/workflows/publish.yml`)
  - Tag-triggered on `v*` (plus a guarded `workflow_dispatch` that requires a `v*` tag ref).
  - Validates the pushed tag matches the `pyproject.toml` version before building.
  - `build` job: `uv build` → uploads `dist/` (sdist + wheel) as a workflow artifact.
  - `publish-pypi` job: downloads the artifact and publishes via `pypa/gh-action-pypi-publish@release/v1` from a `pypi` GitHub environment with `id-token: write` (OIDC) and Sigstore attestations.
- **README** — adds Method 4 (install from PyPI via `pip` / `pipx` / `uv tool`) and updates the install-method count.
- **Version bump** to `0.2.0` (the first PyPI release); `uv.lock` updated to match.
- **PyPI packaging metadata** — adds `readme = "README.md"`, `license = "Apache-2.0"` (SPDX) and `license-files = ["LICENSE"]` so the PyPI page renders the README and shows the license; bumps the setuptools build floor to `>=77.0.0` (PEP 639). Without these, the published page had no description and no license.

## Operator setup (one-time, before tagging)

Trusted Publishing stores no secrets, but it must be registered once:

1. On PyPI, add a **pending publisher** for project `fessctl`:
   - Owner `codelibs`, Repository `fessctl`
   - Workflow filename `publish.yml`
   - Environment name `pypi`
2. In the `codelibs/fessctl` repo settings, create a GitHub Environment named **`pypi`** (optionally with required reviewers / tag protection).

## Test plan

- [x] `uv build` produces `fessctl-0.2.0.tar.gz` + `fessctl-0.2.0-py3-none-any.whl`.
- [x] Built wheel exposes the `fessctl = fessctl.cli:main` console script (`entry_points.txt`).
- [x] Wheel metadata carries `License-Expression: Apache-2.0`, `Description-Content-Type: text/markdown` and the rendered README; LICENSE bundled under `dist-info/licenses/` (no setuptools deprecation warnings).
- [x] `uv lock` updates only the project version (`0.2.0.dev0` → `0.2.0`); no dependency drift.
- [x] `pytest tests/unit` — 104 passed.
- [ ] Operator: register the PyPI pending publisher and create the `pypi` GitHub environment.
- [ ] Operator: tag `v0.2.0` and confirm the workflow publishes to PyPI.
- [ ] Operator: `pip install fessctl && fessctl --help` on a clean machine.
